### PR TITLE
fix packaging of the dependencies into the assembly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := "Overwatch"
+name := "overwatch"
 
 organization := "com.databricks.labs"
 
@@ -8,12 +8,12 @@ scalaVersion := "2.11.12"
 scalacOptions ++= Seq("-Xmax-classfile-name", "78")
 
 val sparkVersion = "2.4.5"
-libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion
-libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion
-libraryDependencies += "org.apache.spark" %% "spark-hive" % sparkVersion
-libraryDependencies += "com.databricks" %% "dbutils-api" % "0.0.4"
+libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion % Provided
+libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion % Provided
+libraryDependencies += "org.apache.spark" %% "spark-hive" % sparkVersion % Provided
+libraryDependencies += "com.databricks" %% "dbutils-api" % "0.0.4" % Provided
 libraryDependencies += "org.scalaj" %% "scalaj-http" % "2.4.2"
-libraryDependencies += "com.microsoft.azure" %% "azure-eventhubs-spark" % "2.3.7"
+libraryDependencies += "com.microsoft.azure" %% "azure-eventhubs-spark" % "2.3.7" % Provided
 
 //libraryDependencies += "io.delta" %% "delta-core" % "0.6.1"
 libraryDependencies += "com.github.mrpowers" %% "spark-fast-tests" % "0.21.3" % Test
@@ -23,6 +23,9 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.2" % Test
 // https://mvnrepository.com/artifact/com.holdenkarau/spark-testing-base
 libraryDependencies += "com.holdenkarau" %% "spark-testing-base" % "2.4.5_0.14.0" % Test
 
+run in Compile := Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run)).evaluated
+runMain in Compile := Defaults.runMainTask(fullClasspath in Compile, runner in(Compile, run)).evaluated
+
 
 // enforce execution of tests during packaging - uncomment next line when we fix dependencies
 // Keys.`package` := (Compile / Keys.`package` dependsOn Test / test).value
@@ -31,14 +34,19 @@ libraryDependencies += "com.holdenkarau" %% "spark-testing-base" % "2.4.5_0.14.0
 //coverageMinimum := 80
 //coverageFailOnMinimum := true
 
-assemblyExcludedJars in assembly := {
-  val cp = (fullClasspath in assembly).value
-  cp filter { f =>
-    f.data.getName.contains("spark-core") ||
-      f.data.getName.contains("spark-sql") ||
-      f.data.getName.contains("spark-hive") ||
-      f.data.getName.contains("azure-eventhubs-spark") ||
-      f.data.getName.contains("delta-core") ||
-      f.data.getName.contains("com.databricks.dbutils-api_2.11")
-  }
-}
+// exclude scala-library dependency
+assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+
+// we'll need this only if we'll exclude some jars
+// assemblyExcludedJars in assembly := {
+//   val cp = (fullClasspath in assembly).value
+//   cp filter { f =>
+//     val filename = f.data.getName
+//     filename.startsWith("scala-library")
+//   }
+// }
+
+// assemblyMergeStrategy in assembly := {
+//  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+//  case x => MergeStrategy.first
+// }

--- a/docs/overwatch_docs/content/UserGuide/Getting Started.md
+++ b/docs/overwatch_docs/content/UserGuide/Getting Started.md
@@ -18,8 +18,6 @@ and the job run setup, Overwatch runs best as a black box -- enable it and forge
 
 ## Dependencies
 Add the following dependencies to your cluster
-* scalaj -- reliable API calls
-    * Maven Coordinate: `org.scalaj:scalaj-http_2.11:2.4.2`
 * plotly -- pretty reporting for some reports, whether or not you will need this depends on the reports you wish 
 to run
     * Default PyPi - Tested with version 4.8.2

--- a/terraform/azure/job/terraform.tfvars
+++ b/terraform/azure/job/terraform.tfvars
@@ -1,5 +1,5 @@
 max_node_count = 2
 cron_expression = "0 15 22 ? * *"
 notebook_path = "/Users/alexey.ott@databricks.com/Overwatch"
-overwatch_jar_path = "../../../target/scala-2.11/overwatch_2.11-0.2_RC1.jar"
+overwatch_jar_path = "../../../target/scala-2.11/overwatch-assembly-0.2_RC1.jar"
 overwatch_remote_path = "/FileStore/jars/overwatch.jar"


### PR DESCRIPTION
* `scalaj` is now included into assembly
* transitive dependencies of the Spark aren't included into assembly anymore