### PR TITLE
corrected AWS orgID 0 on ST shards

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Initializer.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Initializer.scala
@@ -409,7 +409,10 @@ object Initializer extends SparkSessionWrapper {
 
     logger.log(Level.INFO, "Initializing Config")
     val config = new Config()
-    config.setOrganizationId(dbutils.notebook.getContext.tags("orgId"))
+    val orgId = if (dbutils.notebook.getContext.tags("orgId") == "0") {
+      dbutils.notebook.getContext.tags("browserHostName").split("\\.")(0)
+    } else dbutils.notebook.getContext.tags("orgId")
+    config.setOrganizationId(orgId)
     config.registerInitialSparkConf(spark.conf.getAll)
     config.setInitialShuffleParts(spark.conf.get("spark.sql.shuffle.partitions").toInt)
     if (debugFlag) {


### PR DESCRIPTION
AWS Single Tenant workspaces were resolving organization_id to "0" when workspace had a named single tenant domain. Corrected to DNS prefix (i.e. demo.cloud.databricks.com) -- organization_id will now = "demo" not "0"