### PR TITLE
Explicitly normalize non-DBFS URIs

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineFunctions.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineFunctions.scala
@@ -7,6 +7,7 @@ import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
+import java.net.URI
 
 object PipelineFunctions {
   private val logger: Logger = Logger.getLogger(this.getClass)
@@ -26,7 +27,7 @@ object PipelineFunctions {
         if (schema == "dbfs") {
           rawPathString.replaceAllLiterally("//", "/")
         } else {
-          rawPathString
+          new URI(rawPathString).normalize().toString
         }
       case None =>
         "dbfs:%s".format(rawPathString.replaceAllLiterally("//", "/"))

--- a/src/test/scala/com/databricks/labs/overwatch/pipeline/PipelineFunctionsTest.scala
+++ b/src/test/scala/com/databricks/labs/overwatch/pipeline/PipelineFunctionsTest.scala
@@ -156,6 +156,11 @@ class PipelineFunctionsTest extends AnyFunSpec with DataFrameComparer with Spark
         PipelineFunctions.cleansePathURI("abfss://test2@aottlrs.dfs.core.windows.net/1235")
       )
     }
+    it("should work for ABFSS double slashes") {
+      assertResult("abfss://test2@aottlrs.dfs.core.windows.net/1235")(
+        PipelineFunctions.cleansePathURI("abfss://test2@aottlrs.dfs.core.windows.net//1235")
+      )
+    }
     it("should work for S3") {
       assertResult("s3a://commoncrawl/path")(
         PipelineFunctions.cleansePathURI("s3a://commoncrawl/path")


### PR DESCRIPTION
There was an error by customer where the URI was built by string concatenation, and
resulted in the string with `//` inside, and that lead to the errors on the second ingest
because URI was normalized by metastore, and comparison of original URI with URI from
metastore failed