### PR TITLE
Fix for SQL Endpoints API Change (issue #134)

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -53,6 +53,24 @@ class Workspace(config: Config) extends SparkSessionWrapper {
 
   }
 
+  // The below function is supposed to fetch data about DatabricksSQLEndPoints
+  def getSqlEndPointsDF: DataFrame = {
+
+    val jobsEndpoint = "sql/endpoints"
+
+    try {
+      ApiCall(jobsEndpoint, config.apiEnv)
+        .executeGet()
+        .asDF
+        .withColumn("organization_id", lit(config.organizationId))
+    } catch {
+      case e: Throwable => {
+        logger.log(Level.ERROR, "ERROR: Failed to execute jobs/list API call.", e)
+        spark.sql("select ERROR")
+      }
+    }
+
+  }
   /**
    * Exposed config as a public getter to enable access to config for testing. This should not be public facing
    * public function.

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -54,7 +54,7 @@ class Workspace(config: Config) extends SparkSessionWrapper {
   }
 
   // The below function is supposed to fetch data about DatabricksSQLEndPoints
-  def getSqlEndPointsDF: DataFrame = {
+  def getDatabricksSqlDF: DataFrame = {
 
     val jobsEndpoint = "sql/endpoints"
 

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTargets.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTargets.scala
@@ -31,6 +31,15 @@ abstract class PipelineTargets(config: Config) {
       partitionBy = Seq("organization_id")
     )
 
+    lazy private[overwatch] val databricksSqlTarget: PipelineTable = PipelineTable(
+      name = "databricks_sql_snapshot_bronze",
+      _keys = Array("id", "Overwatch_RunID"),
+      config,
+      incrementalColumns = Array("Pipeline_SnapTS"),
+      statsColumns = "created_time, creator_user_name, id, Pipeline_SnapTS, Overwatch_RunID".split(", "),
+      partitionBy = Seq("organization_id")
+    )
+
     lazy private[overwatch] val clustersSnapshotTarget: PipelineTable = PipelineTable(
       name = "clusters_snapshot_bronze",
       _keys = Array("cluster_id", "Overwatch_RunID"),


### PR DESCRIPTION
## EndPoint Documentation 
https://databrickslabs.github.io/overwatch/

#### What are we trying to solve
https://github.com/databrickslabs/overwatch/issues/134


### What needs to be captured 

1. states of endpoints through time
2. usage of endpoints through time
3. spec of endpoints through time
4. queries history, etc


once you have the inventory, create example DFs of what everything is going to look like in bronze (raw data) -- then see how it moves to silver and gold such that a user can see

1. the queries
2. the endpoints specs through time and how they've changed
3. the endpoint states through time
4. the costs
5. the query runtime metrics


yeah use the APIs and the Audit logs to essentially data mine out all the data points you have and create your inventory of what you have / don't have...from there we can work on the gold entities and start transforming the data to get there. I usually do most of this in notebooks to start, then I copy and paste the ETL code into Overwatch and pass in vars

## Ingestion points for Databricks SQL
We will need to consume data from multiple API endpoints and Audit logs.

List of End points to consume from:

1. "sql/endpoints"
2. "sql/history/queries"  The query string for the get request is include_metrics=true.

 



Audit logs:

1. Query audit_log_bronze table with alteast three different type of queries becuase Databricks SQL has been renamed. Example env https://adb-2222170229861029.9.azuredatabricks.net/?o=2222170229861029#setting/clusters/0608-082040-snore201/configuration










Use the database name: overwatch_etl

## Tasks

- [x]  1.  Get the dataframe from API . This will be defined in Workspace.scala. It will be similar to that of clusers_snapshot_bronze and jobs_snapshot_bronze this will act as a lookup for missing audit data in Silver
- [x] 2. Define a endPointsTarget.  Just make sure it's defined as a Bronze target
- [ ] 3. Create a module inside Bronze.   Make sure it has an appropriate module ID and name. The schema scrubber implementation should NOT be INSIDE BRONZE -- but rather a function defined inside the trait, BronzeTransforms -- as needed
- [ ] 4. You create a process that implements ETL Definition inside Bronze.scala . You create a process that implements ETL Definition inside Bronze.scala -- this is what will actually call the functions in the BronzeTransformations that perform the schema cleansing, etc
- [ ] 5. Create a pipeline to execute the module and load the Target.  Bronze() is a pipeline so all you need to do is check the Overwatch scope to see if sqlAnalytics is present -- if it is, execute the process defined in Step 4, otherwise skip
which leads to step 0-ish which is likely add sqlAnalytics scope to the Overwatch Scope enumeration object and validate any requisite dependencies (there may not be any in bronze)


## What has been completed so far?
Currently, completed the task 1 & 2. Looking for an initial check to see if I am heading in the right direction. I am not sure if the target definition is correct or not .

I will wait for your feedback and then start with Task 3
