### PR TITLE
Fix laggard df

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "overwatch"
 
 organization := "com.databricks.labs"
 
-version := "0.5.0"
+version := "0.5.0.1"
 
 scalaVersion := "2.12.12"
 scalacOptions ++= Seq("-Xmax-classfile-name", "78")

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/BronzeTransforms.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/BronzeTransforms.scala
@@ -723,20 +723,21 @@ trait BronzeTransforms extends SparkSessionWrapper {
       .withColumn("cluster_log_conf", get_json_object('cluster_log_conf, "$.destination"))
       .filter('cluster_log_conf.isNotNull)
 
-    // Get latest incremental snapshot of clusters running during current run
+    // Get latest incremental snapshot of clusters with logging dirs but not existing in audit updates
     // This captures clusters that have not been edited/restarted since the last run and are still RUNNING with
     // log confs as they will not be in the audit logs
-    val latestSnapW = Window.partitionBy('organization_id).orderBy('Pipeline_SnapTS.desc)
-    val currentlyRunningClustersWithLogging = clusterSnapshot
+    val latestSnapW = Window.partitionBy('organization_id, 'cluster_id).orderBy('Pipeline_SnapTS.desc)
+    val newLogDirsNotIdentifiedInAudit = clusterSnapshot
+      .join(incrementalClusterIDs, Seq("cluster_id"))
       .withColumn("snapRnk", rank.over(latestSnapW))
-      .filter('snapRnk === 1 && 'state === "RUNNING")
+      .filter('snapRnk === 1)
       .withColumn("cluster_log_conf", coalesce($"cluster_log_conf.dbfs.destination", $"cluster_log_conf.s3.destination"))
       .filter('cluster_id.isNotNull && 'cluster_log_conf.isNotNull)
       .select('cluster_id, 'cluster_log_conf)
 
     // Build root level eventLog path prefix from clusterID and log conf
     // /some/log/prefix/cluster_id/eventlog
-    val allEventLogPrefixes = currentlyRunningClustersWithLogging
+    val allEventLogPrefixes = newLogDirsNotIdentifiedInAudit
       .unionByName(incrementalClusterWLogging)
       .withColumn("cluster_log_conf", when('cluster_log_conf.endsWith("/"), 'cluster_log_conf.substr(lit(0), length('cluster_log_conf) - 1)).otherwise('cluster_log_conf))
       .withColumn("topLevelTargets", array(col("cluster_log_conf"), col("cluster_id"), lit("eventlog")))

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/BronzeTransforms.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/BronzeTransforms.scala
@@ -724,7 +724,7 @@ trait BronzeTransforms extends SparkSessionWrapper {
       .filter('cluster_log_conf.isNotNull)
 
     // Get latest incremental snapshot of clusters with logging dirs but not existing in audit updates
-    // This captures clusters that have not been edited/restarted since the last run and are still RUNNING with
+    // This captures clusters that have not been edited/restarted since the last run with
     // log confs as they will not be in the audit logs
     val latestSnapW = Window.partitionBy('organization_id, 'cluster_id).orderBy('Pipeline_SnapTS.desc)
     val newLogDirsNotIdentifiedInAudit = clusterSnapshot

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTable.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTable.scala
@@ -189,7 +189,7 @@ case class PipelineTable(
   def asIncrementalDF(
                        module: Module,
                        cronColumnsNames: Seq[String],
-                       additionalLagDays: Int = 0
+                       additionalLagDays: Long = 0
                      ): DataFrame = {
     val moduleId = module.moduleId
     val moduleName = module.moduleName
@@ -223,7 +223,7 @@ case class PipelineTable(
             }
             IncrementalFilter(
               field,
-              date_sub(module.fromTime.asColumnTS.cast(dt), additionalLagDays),
+              date_sub(module.fromTime.asColumnTS.cast(dt), additionalLagDays.toInt),
               module.untilTime.asColumnTS.cast(dt)
             )
           }
@@ -244,7 +244,7 @@ case class PipelineTable(
             val start = if (additionalLagDays > 0) {
               lit(module.fromTime.asUnixTimeMilli - (additionalLagDays * 24 * 60 * 60 * 1000)).cast(dt)
             } else {
-              module.fromTime.asColumnTS
+              lit(module.fromTime.asUnixTimeMilli)
             }
             IncrementalFilter(
               field,

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTable.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTable.scala
@@ -240,10 +240,15 @@ case class PipelineTable(
               module.untilTime.asColumnTS
             )
           }
-          case _: LongType => {
+          case dt: LongType => {
+            val start = if (additionalLagDays > 0) {
+              lit(module.fromTime.asUnixTimeMilli - (additionalLagDays * 24 * 60 * 60 * 1000)).cast(dt)
+            } else {
+              module.fromTime.asColumnTS
+            }
             IncrementalFilter(
               field,
-              lit(module.fromTime.asUnixTimeMilli),
+              start,
               lit(module.untilTime.asUnixTimeMilli)
             )
           }


### PR DESCRIPTION
The laggard DFs had a bug wherein when incremental type was LongType, the filter was not getting created correctly. This should improve accuracy and completeness in daily runs.