### PR TITLE
changes alreadyProcessed files to filter withinSpecifiedTimeRange

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/BronzeTransforms.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/BronzeTransforms.scala
@@ -464,7 +464,7 @@ trait BronzeTransforms extends SparkSessionWrapper {
                                                processedLogFiles: PipelineTable): DataFrame = {
     val validNewFiles = if (processedLogFiles.exists) {
       val alreadyProcessed = processedLogFiles.asDF
-        .filter(!'failed)
+        .filter(!'failed && 'withinSpecifiedTimeRange)
         .select('filename)
         .distinct
 


### PR DESCRIPTION
changes alreadyProcessed files to filter withinSpecifiedTimeRange to avoid skipping files which were not previously ingested due to being out of the ingestion time ranges.

fix for issue #214

After this change files which were left are successfully ingested:

```
dbfs:/cluster-logs/0825-072207-odors29/eventlog/0825-072207-odors29_10_225_145_197/8857842030320760060/eventlog
2021-08-25T08:15:32.000+0000
2021-08-25T09:03:49.000+0000
false
dbfs:/cluster-logs/0825-072207-odors29/eventlog/0825-072207-odors29_10_225_145_197/8857842030320760060/eventlog
2021-08-26T08:18:13.000+0000
2021-08-25T10:40:14.000+0000
true
```

Data ingestion into bronze/silver show complete data now.

