### PR TITLE
refactored sparkOverrides to be tied to module.

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/env/Database.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Database.scala
@@ -123,7 +123,6 @@ class Database(config: Config) extends SparkSessionWrapper {
   }
 
   def write(df: DataFrame, target: PipelineTable, pipelineSnapTime: Column, applySparkOverrides: Boolean = true): Boolean = {
-    if (applySparkOverrides) target.applySparkOverrides()
     var finalDF: DataFrame = df
     finalDF = if (target.withCreateDate) finalDF.withColumn("Pipeline_SnapTS", pipelineSnapTime) else finalDF
     finalDF = if (target.withOverwatchRunID) finalDF.withColumn("Overwatch_RunID", lit(config.runID)) else finalDF

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Pipeline.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Pipeline.scala
@@ -376,7 +376,6 @@ class Pipeline(
   }
 
   private[overwatch] def append(target: PipelineTable)(df: DataFrame, module: Module): ModuleStatusReport = {
-    target.applySparkOverrides()
     val startTime = System.currentTimeMillis()
 
     //      if (!target.exists && !module.isFirstRun) throw new PipelineStateException("MODULE STATE EXCEPTION: " +

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTable.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTable.scala
@@ -32,7 +32,7 @@ case class PipelineTable(
                           zOrderBy: Array[String] = Array(),
                           vacuum_H: Int = 24 * 7, // TODO -- allow config overrides -- no vacuum == 0
                           enableSchemaMerge: Boolean = true,
-                          sparkOverrides: Map[String, String] = Map[String, String](),
+//                          sparkOverrides: Map[String, String] = Map[String, String](),
                           withCreateDate: Boolean = true,
                           withOverwatchRunID: Boolean = true,
                           isTemp: Boolean = false,
@@ -41,8 +41,6 @@ case class PipelineTable(
                         ) extends SparkSessionWrapper {
 
   private val logger: Logger = Logger.getLogger(this.getClass)
-  private var currentSparkOverrides: Map[String, String] = sparkOverrides
-  logger.log(Level.INFO, s"Spark Overrides Initialized for target: ${_databaseName}.${name} to\n${currentSparkOverrides.mkString(", ")}")
 
   import spark.implicits._
 
@@ -97,15 +95,6 @@ case class PipelineTable(
     }
     else spark.conf.set("spark.databricks.delta.properties.defaults.autoOptimize.autoCompact", "false")
 
-    if (updates.nonEmpty) {
-      currentSparkOverrides = currentSparkOverrides ++ updates
-    }
-
-    if (currentSparkOverrides.nonEmpty) {
-      PipelineFunctions.setSparkOverrides(spark, currentSparkOverrides, config.debugFlag)
-    } else {
-      logger.log(Level.INFO, s"USING spark conf defaults for $tableFullName")
-    }
   }
 
   def tableIdentifier: Option[TableIdentifier] = {
@@ -343,7 +332,6 @@ case class PipelineTable(
       else dfWriter
       dfWriter
     }
-
   }
 
 

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTargets.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTargets.scala
@@ -92,13 +92,6 @@ abstract class PipelineTargets(config: Config) {
       statsColumns = ("organization_id, Event, clusterId, SparkContextId, JobID, StageID," +
         "StageAttemptID, TaskType, ExecutorID, fileCreateDate, fileCreateEpochMS, fileCreateTS, filename," +
         "Pipeline_SnapTS, Overwatch_RunID").split(", "),
-      sparkOverrides = Map(
-        "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
-        "spark.databricks.delta.optimizeWrite.binSize" -> "2048",
-        "spark.sql.files.maxPartitionBytes" -> (1024 * 1024 * 64).toString
-        // very large schema to imply, too much parallelism and schema result size is too large to
-        // serialize, 64m seems to be a good middle ground.
-      ),
       autoOptimize = true, // TODO -- perftest
       masterSchema = Some(Schema.sparkEventsRawMasterSchema)
     )
@@ -147,10 +140,6 @@ abstract class PipelineTargets(config: Config) {
       partitionBy = Seq("organization_id"),
       incrementalColumns = Array("addedTimestamp"),
       autoOptimize = true,
-      sparkOverrides = Map(
-        "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
-        "spark.databricks.delta.optimizeWrite.binSize" -> "2048"
-      ),
       shuffleFactor = 0.25
     )
 
@@ -161,10 +150,6 @@ abstract class PipelineTargets(config: Config) {
       partitionBy = Seq("organization_id"),
       incrementalColumns = Array("startTimestamp"),
       autoOptimize = true,
-      sparkOverrides = Map(
-        "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
-        "spark.databricks.delta.optimizeWrite.binSize" -> "2048"
-      ),
       shuffleFactor = 0.25
     )
 
@@ -175,11 +160,6 @@ abstract class PipelineTargets(config: Config) {
       incrementalColumns = Array("startDate", "startTimestamp"),
       partitionBy = Seq("organization_id", "startDate"),
       autoOptimize = true,
-      sparkOverrides = Map(
-        "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
-        "spark.databricks.delta.optimizeWrite.binSize" -> "2048",
-        "spark.sql.files.maxPartitionBytes" -> (1024 * 1024 * 64).toString
-      ),
       shuffleFactor = 0.75
     )
 
@@ -190,10 +170,6 @@ abstract class PipelineTargets(config: Config) {
       incrementalColumns = Array("startDate", "startTimestamp"),
       partitionBy = Seq("organization_id", "startDate"),
       autoOptimize = true,
-      sparkOverrides = Map(
-        "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
-        "spark.databricks.delta.optimizeWrite.binSize" -> "2048"
-      ),
       shuffleFactor = 0.25
     )
 
@@ -204,11 +180,7 @@ abstract class PipelineTargets(config: Config) {
       incrementalColumns = Array("startDate", "startTimestamp"),
       partitionBy = Seq("organization_id", "startDate"),
       shuffleFactor = 5,
-      autoOptimize = true,
-      sparkOverrides = Map(
-        "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
-        "spark.databricks.delta.optimizeWrite.binSize" -> "2048" // output is very dense, shrink output file size
-      )
+      autoOptimize = true
     )
 
     lazy private[overwatch] val dbJobRunsTarget: PipelineTable = PipelineTable(
@@ -311,10 +283,7 @@ abstract class PipelineTargets(config: Config) {
       _keys = Array("job_id", "id_in_job"),
       config,
       incrementalColumns = Array("endEpochMS"),
-      partitionBy = Seq("organization_id", "__overwatch_ctrl_noise"),
-      sparkOverrides = Map(
-        "spark.sql.autoBroadcastJoinThreshold" -> "-1"
-      )
+      partitionBy = Seq("organization_id", "__overwatch_ctrl_noise")
     )
 
     lazy private[overwatch] val jobRunCostPotentialFactViewTarget: PipelineView = PipelineView(
@@ -389,10 +358,6 @@ abstract class PipelineTargets(config: Config) {
       partitionBy = Seq("organization_id", "date"),
       incrementalColumns = Array("date", "unixTimeMS"),
       autoOptimize = true,
-      sparkOverrides = Map(
-        "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
-        "spark.databricks.delta.optimizeWrite.binSize" -> "2048" // output is very dense, shrink output file size
-      ),
       zOrderBy = Array("cluster_id")
     )
 
@@ -409,10 +374,6 @@ abstract class PipelineTargets(config: Config) {
       partitionBy = Seq("organization_id", "date"),
       incrementalColumns = Array("date", "unixTimeMS"),
       autoOptimize = true,
-      sparkOverrides = Map(
-        "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
-        "spark.databricks.delta.optimizeWrite.binSize" -> "2048" // output is very dense, shrink output file size
-      ),
       zOrderBy = Array("cluster_id")
     )
 
@@ -430,11 +391,7 @@ abstract class PipelineTargets(config: Config) {
       zOrderBy = Array("cluster_id"),
       incrementalColumns = Array("date", "unixTimeMS"),
       shuffleFactor = 5,
-      autoOptimize = true,
-      sparkOverrides = Map(
-        "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000", // output is very skewed by partition
-        "spark.databricks.delta.optimizeWrite.binSize" -> "2048" // output is very dense, shrink output file size
-      )
+      autoOptimize = true
     )
 
     lazy private[overwatch] val sparkTaskViewTarget: PipelineView = PipelineView(
@@ -449,11 +406,7 @@ abstract class PipelineTargets(config: Config) {
       config,
       partitionBy = Seq("organization_id"),
       incrementalColumns = Array("unixTimeMS"),
-      autoOptimize = true,
-      sparkOverrides = Map(
-        "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
-        "spark.databricks.delta.optimizeWrite.binSize" -> "2048" // output is very dense, shrink output file size
-      )
+      autoOptimize = true
     )
 
     lazy private[overwatch] val sparkExecutionViewTarget: PipelineView = PipelineView(
@@ -468,11 +421,7 @@ abstract class PipelineTargets(config: Config) {
       config,
       partitionBy = Seq("organization_id"),
       incrementalColumns = Array("unixTimeMS"),
-      autoOptimize = true,
-      sparkOverrides = Map(
-        "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
-        "spark.databricks.delta.optimizeWrite.binSize" -> "2048" // output is very dense, shrink output file size
-      )
+      autoOptimize = true
     )
 
     lazy private[overwatch] val sparkExecutorViewTarget: PipelineView = PipelineView(

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala
@@ -106,7 +106,12 @@ class Silver(_workspace: Workspace, _database: Database, _config: Config)
   //    Module(2002, "SPARK_JDBC_Operations_Raw")
   //  )
 
+  private val sparkExecutorsSparkOverrides = Map(
+    "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
+    "spark.databricks.delta.optimizeWrite.binSize" -> "2048"
+  )
   lazy private[overwatch] val executorsModule = Module(2003, "Silver_SPARK_Executors", this, Array(1006))
+    .withSparkOverrides(sparkExecutorsSparkOverrides)
   lazy private val appendExecutorsProcess = ETLDefinition(
     BronzeTargets.sparkEventLogsTarget
       .asIncrementalDF(executorsModule, 2, "fileCreateDate", "fileCreateEpochMS"),
@@ -122,7 +127,12 @@ class Silver(_workspace: Workspace, _database: Database, _config: Config)
   //    Module(2004, "SPARK_Applications_Raw")
   //  )
 
+  private val sparkExecutionsSparkOverrides = Map(
+    "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
+    "spark.databricks.delta.optimizeWrite.binSize" -> "2048"
+  )
   lazy private[overwatch] val executionsModule = Module(2005, "Silver_SPARK_Executions", this, Array(1006), 8.0)
+    .withSparkOverrides(sparkExecutionsSparkOverrides)
   lazy private val appendExecutionsProcess = ETLDefinition(
     BronzeTargets.sparkEventLogsTarget
       .asIncrementalDF(executionsModule, 2, "fileCreateDate", "fileCreateEpochMS"),
@@ -130,7 +140,13 @@ class Silver(_workspace: Workspace, _database: Database, _config: Config)
     append(SilverTargets.executionsTarget)
   )
 
+  private val sparkJobsSparkOverrides = Map(
+    "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
+    "spark.databricks.delta.optimizeWrite.binSize" -> "2048",
+    "spark.sql.files.maxPartitionBytes" -> (1024 * 1024 * 64).toString
+  )
   lazy private[overwatch] val sparkJobsModule = Module(2006, "Silver_SPARK_Jobs", this, Array(1006), 8.0)
+    .withSparkOverrides(sparkJobsSparkOverrides)
   lazy private val appendSparkJobsProcess = ETLDefinition(
     BronzeTargets.sparkEventLogsTarget
       .asIncrementalDF(sparkJobsModule, 2, "fileCreateDate", "fileCreateEpochMS"),
@@ -138,7 +154,12 @@ class Silver(_workspace: Workspace, _database: Database, _config: Config)
     append(SilverTargets.jobsTarget)
   )
 
+  private val sparkStagesSparkOverrides = Map(
+    "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
+    "spark.databricks.delta.optimizeWrite.binSize" -> "2048"
+  )
   lazy private[overwatch] val sparkStagesModule = Module(2007, "Silver_SPARK_Stages", this, Array(1006), 8.0)
+    .withSparkOverrides(sparkStagesSparkOverrides)
   lazy private val appendSparkStagesProcess = ETLDefinition(
     BronzeTargets.sparkEventLogsTarget
       .asIncrementalDF(sparkStagesModule, 2, "fileCreateDate", "fileCreateEpochMS"),
@@ -146,7 +167,12 @@ class Silver(_workspace: Workspace, _database: Database, _config: Config)
     append(SilverTargets.stagesTarget)
   )
 
+  private val sparkTasksSparkOverrides = Map(
+    "spark.databricks.delta.optimizeWrite.numShuffleBlocks" -> "500000",
+    "spark.databricks.delta.optimizeWrite.binSize" -> "2048" // output is very dense, shrink output file size
+  )
   lazy private[overwatch] val sparkTasksModule = Module(2008, "Silver_SPARK_Tasks", this, Array(1006), 8.0)
+    .withSparkOverrides(sparkTasksSparkOverrides)
   lazy private val appendSparkTasksProcess = ETLDefinition(
     BronzeTargets.sparkEventLogsTarget
       .asIncrementalDF(sparkTasksModule, 2, "fileCreateDate", "fileCreateEpochMS"),

--- a/src/main/scala/com/databricks/labs/overwatch/validation/Scenarios.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/validation/Scenarios.scala
@@ -151,7 +151,7 @@ object Scenarios extends SparkSessionWrapper {
     CostComputeCalculation: Checks if the driver and worker costs add correctly to the total: driver_compute_cost + worker_compute_cost = total_compute_cost, check absolute difference < 0.000002
     CostDBUCalculation: Checks if the driver and worker DBUs add correctly to the total: driver_dbu_cost + worker_dbu_cost = total_dbu_cost, , check absolute difference < 0.000002
     CostTotalCalculation: Checks if the DBU and compute costs add correctly to the total: total_compute_cost + total_dbu_cost = total_cost, , check absolute difference < 0.000002
-    JobRunningDaysInvalid: Checks if list of running days is sane: date(startTS) = min(running_days) and date(endTS) = max(running_days)
+    JobRunningDaysInvalid: Checks if list of running days is sane: date(startTS) := min(running_days) and date(endTS) = max(running_days)
     * @param dbName
     */
   def jobruncostpotentialfact(dbName: String): DataFrame = {


### PR DESCRIPTION
spark overrides were not always being honored in the pipeline. Tying them to module is the better way to go. This is especially important for JRCP to disable autoBroadcastJoin (reason for the ticket)

closes #192 