### PR TITLE
[DRAFT] Filter out the "non-standard" tags coming as default_tags

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/BronzeTransforms.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/BronzeTransforms.scala
@@ -203,6 +203,7 @@ trait BronzeTransforms extends SparkSessionWrapper {
 
     outputDF
       .withColumn("custom_tags", SchemaTools.structToMap(outputDF, "custom_tags"))
+      .withColumn("default_tags", SchemaTools.structToMap(outputDF, "default_tags"))
       .withColumn("spark_conf", SchemaTools.structToMap(outputDF, "spark_conf"))
       .withColumn("spark_env_vars", SchemaTools.structToMap(outputDF, "spark_env_vars"))
       .withColumn(s"${cloudProvider}_attributes", SchemaTools.structToMap(outputDF, s"${cloudProvider}_attributes"))
@@ -212,6 +213,7 @@ trait BronzeTransforms extends SparkSessionWrapper {
   protected def cleanseRawPoolsDF()(df: DataFrame): DataFrame = {
     val outputDF = SchemaTools.scrubSchema(df)
     outputDF.withColumn("custom_tags", SchemaTools.structToMap(outputDF, "custom_tags"))
+      .withColumn("default_tags", SchemaTools.structToMap(outputDF, "default_tags"))
   }
 
   //noinspection ScalaCustomHdfsFormat


### PR DESCRIPTION
Databricks adds a number of the default tags, like, Creator, ClusterName, ClusterId,
etc. that are returned as `default_tags` objects in the REST API Clusters Get call.  But
this block also returns the tags inherited from the Azure resource group, workspace, etc.
But this block is treated as Spark struct column, and this leads to addition of the
"non-standard" names that are becoming the fields of struct. But in case of mixing the
casing of the same name, the processing is failing when writing data into Delta table.

This fix doing two things:
* leaving only Databricks-specific tags in the `default_tags` column
* converting the original `default_tags` data coming from API into a separate column of
  the map type, so users will still able to query the data using the "non-standard" tags

this fixes #260