### PR TITLE
enable custom workspace names

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/ParamDeserializer.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/ParamDeserializer.scala
@@ -158,6 +158,8 @@ class ParamDeserializer() extends StdDeserializer[OverwatchParams](classOf[Overw
       getOptionDouble(masterNode, "intelligentScaling.coeff").getOrElse(1.0)
     )
 
+    val workspaceFriendlyName = getOptionString(masterNode, "workspaceFriendlyName")
+
     OverwatchParams(
       auditLogConfig,
       token,
@@ -167,7 +169,8 @@ class ParamDeserializer() extends StdDeserializer[OverwatchParams](classOf[Overw
       maxDaysToLoad,
       dbContractPrices,
       primordialDateString,
-      intelligentScalingConfig
+      intelligentScalingConfig,
+      workspaceFriendlyName
     )
   }
 }

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/GoldTransforms.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/GoldTransforms.scala
@@ -794,7 +794,7 @@ trait GoldTransforms extends SparkSessionWrapper {
 
   protected val clusterViewColumnMapping: String =
     """
-      |organization_id, cluster_id, action, unixTimeMS, timestamp, date, cluster_name, driver_node_type, node_type, num_workers,
+      |organization_id, workspace_name, cluster_id, action, unixTimeMS, timestamp, date, cluster_name, driver_node_type, node_type, num_workers,
       |autoscale, auto_termination_minutes, enable_elastic_disk, is_automated, cluster_type, security_profile, cluster_log_conf,
       |init_scripts, custom_tags, cluster_source, spark_env_vars, spark_conf, acl_path_prefix,
       |driver_instance_pool_id, instance_pool_id, driver_instance_pool_name, instance_pool_name,
@@ -803,28 +803,28 @@ trait GoldTransforms extends SparkSessionWrapper {
 
   protected val poolsViewColumnMapping: String =
     """
-      |organization_id, instance_pool_id, serviceName, timestamp, date, actionName, instance_pool_name, node_type_id,
+      |organization_id, workspace_name, instance_pool_id, serviceName, timestamp, date, actionName, instance_pool_name, node_type_id,
       |idle_instance_autotermination_minutes, min_idle_instances, max_capacity, preloaded_spark_versions,
       |azure_attributes, create_details, delete_details, request_details, poolSnapDetails
       |""".stripMargin
 
   protected val jobViewColumnMapping: String =
     """
-      |organization_id, job_id, action, unixTimeMS, timestamp, date, job_name, job_type, timeout_seconds, schedule,
+      |organization_id, workspace_name, job_id, action, unixTimeMS, timestamp, date, job_name, job_type, timeout_seconds, schedule,
       |notebook_path, new_settings, cluster, aclPermissionSet, grants, targetUserId, session_id, request_id, user_agent,
       |response, source_ip_address, created_by, created_ts, deleted_by, deleted_ts, last_edited_by, last_edited_ts
       |""".stripMargin
 
   protected val jobRunViewColumnMapping: String =
     """
-      |organization_id, run_id, run_name, job_runtime, job_id, id_in_job, job_cluster_type, job_task_type,
+      |organization_id, workspace_name, run_id, run_name, job_runtime, job_id, id_in_job, job_cluster_type, job_task_type,
       |job_terminal_state, job_trigger_type, cluster_id, notebook_params, libraries, children, workflow_context,
       |task_detail, request_detail, time_detail
       |""".stripMargin
 
   protected val jobRunCostPotentialFactViewColumnMapping: String =
     """
-      |organization_id, run_id, job_id, id_in_job, job_runtime, run_terminal_state, run_trigger_type, run_task_type, cluster_id,
+      |organization_id, workspace_name, run_id, job_id, id_in_job, job_runtime, run_terminal_state, run_trigger_type, run_task_type, cluster_id,
       |cluster_name, cluster_type, custom_tags, driver_node_type_id, node_type_id, dbu_rate, running_days,
       |run_cluster_states, avg_cluster_share, avg_overlapping_runs, max_overlapping_runs, worker_potential_core_H,
       |driver_compute_cost, driver_dbu_cost, worker_compute_cost, worker_dbu_cost, total_driver_cost, total_worker_cost,
@@ -833,25 +833,25 @@ trait GoldTransforms extends SparkSessionWrapper {
 
   protected val notebookViewColumnMappings: String =
     """
-      |organization_id, notebook_id, notebook_name, notebook_path, cluster_id, action, unixTimeMS, timestamp, date, old_name, old_path,
+      |organization_id, workspace_name, notebook_id, notebook_name, notebook_path, cluster_id, action, unixTimeMS, timestamp, date, old_name, old_path,
       |new_name, new_path, parent_path, user_email, request_id, response
       |""".stripMargin
 
   protected val accountModViewColumnMappings: String =
     """
-      |organization_id, mod_unixTimeMS, mod_date, action, endpoint, modified_by, user_name, user_id,
+      |organization_id, workspace_name, mod_unixTimeMS, mod_date, action, endpoint, modified_by, user_name, user_id,
       |group_name, group_id, from_ip_address, user_agent, request_id, response
       |""".stripMargin
 
   protected val accountLoginViewColumnMappings: String =
     """
-      |organization_id, login_unixTimeMS, login_date, login_type, login_user, user_email, ssh_login_details
+      |organization_id, workspace_name, login_unixTimeMS, login_date, login_type, login_user, user_email, ssh_login_details
       |from_ip_address, user_agent, request_id, response
       |""".stripMargin
 
   protected val clusterStateFactViewColumnMappings: String =
     """
-      |organization_id, cluster_id, cluster_name, custom_tags, state_start_date, unixTimeMS_state_start, unixTimeMS_state_end,
+      |organization_id, workspace_name, cluster_id, cluster_name, custom_tags, state_start_date, unixTimeMS_state_start, unixTimeMS_state_end,
       |timestamp_state_start, timestamp_state_end, state, driver_node_type_id, node_type_id, current_num_workers,
       |target_num_workers, uptime_since_restart_S, uptime_in_state_S, uptime_in_state_H, cloud_billable,
       |databricks_billable, isAutomated, dbu_rate, state_dates, days_in_state, worker_potential_core_H, core_hours,
@@ -861,33 +861,33 @@ trait GoldTransforms extends SparkSessionWrapper {
 
   protected val sparkJobViewColumnMapping: String =
     """
-      |organization_id, spark_context_id, job_id, job_group_id, execution_id, stage_ids, cluster_id, notebook_id, notebook_path,
+      |organization_id, workspace_name, spark_context_id, job_id, job_group_id, execution_id, stage_ids, cluster_id, notebook_id, notebook_path,
       |db_job_id, db_id_in_job, db_job_type, unixTimeMS, timestamp, date, job_runtime, job_result, event_log_start,
       |event_log_end, user_email
       |""".stripMargin
 
   protected val sparkStageViewColumnMapping: String =
     """
-      |organization_id, spark_context_id, stage_id, stage_attempt_id, cluster_id, unixTimeMS, timestamp, date, stage_runtime,
+      |organization_id, workspace_name, spark_context_id, stage_id, stage_attempt_id, cluster_id, unixTimeMS, timestamp, date, stage_runtime,
       |stage_info, event_log_start, event_log_end
       |""".stripMargin
 
   protected val sparkTaskViewColumnMapping: String =
     """
-      |organization_id, spark_context_id, task_id, task_attempt_id, stage_id, stage_attempt_id, cluster_id, executor_id, host,
+      |organization_id, workspace_name, spark_context_id, task_id, task_attempt_id, stage_id, stage_attempt_id, cluster_id, executor_id, host,
       |unixTimeMS, timestamp, date, task_runtime, task_metrics, task_info, task_type, task_end_reason,
       |event_log_start, event_log_end
       |""".stripMargin
 
   protected val sparkExecutionViewColumnMapping: String =
     """
-      |organization_id, spark_context_id, execution_id, cluster_id, description, details, unixTimeMS, timestamp, date,
+      |organization_id, workspace_name, spark_context_id, execution_id, cluster_id, description, details, unixTimeMS, timestamp, date,
       |sql_execution_runtime, event_log_start, event_log_end
       |""".stripMargin
 
   protected val sparkExecutorViewColumnMapping: String =
     """
-      |organization_id, spark_context_id, executor_id, cluster_id, executor_info, removed_reason, executor_alivetime,
+      |organization_id, workspace_name, spark_context_id, executor_id, cluster_id, executor_info, removed_reason, executor_alivetime,
       |unixTimeMS, timestamp, date, event_log_start, event_log_end
       |""".stripMargin
 

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Initializer.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Initializer.scala
@@ -21,10 +21,12 @@ class Initializer(config: Config) extends SparkSessionWrapper {
 
   private val logger: Logger = Logger.getLogger(this.getClass)
   private var _isSnap: Boolean = false
+
   private def setIsSnap(value: Boolean): this.type = {
     _isSnap = value
     this
   }
+
   private def isSnap: Boolean = _isSnap
 
   /**
@@ -155,6 +157,30 @@ class Initializer(config: Config) extends SparkSessionWrapper {
     this
   }
 
+  private def isPVC: Boolean = {
+    val lowerOrgId = config.organizationId.toLowerCase
+    if (lowerOrgId.contains("ilb") || lowerOrgId.contains("elb")) {
+      val pvcDetectedMsg = "Databricks PVC: PVC WORKSPACE DETECTED!"
+      config.setIsPVC(true)
+      if (config.debugFlag) println(pvcDetectedMsg)
+      logger.log(Level.INFO, pvcDetectedMsg)
+      require(config.workspaceFriendlyName.toLowerCase != config.organizationId.toLowerCase,
+        s"PVC workspaces require the 'workspaceFriendlyName' to be configured in the Overwatch configs for " +
+          s"data continuity. Please choose a friendly workspace name and add it to the configuration and try to " +
+          s"run the pipeline again."
+      )
+      true
+    } else false
+  }
+
+  private def pvcOverrideOrganizationId: Unit = {
+    val overrideMsg = s"Databricks PVC: Overriding organization_id from ${config.organizationId} to " +
+      s"${config.workspaceFriendlyName} to accommodate data continuity across deployments"
+    if (config.debugFlag) println(overrideMsg)
+    logger.log(Level.INFO, overrideMsg)
+    config.setOrganizationId(config.workspaceFriendlyName)
+  }
+
   /**
    * Convert the args brought in as JSON string into the paramters object "OverwatchParams".
    * Validate the config and the environment readiness for the run based on the configs and environment state
@@ -185,8 +211,8 @@ class Initializer(config: Config) extends SparkSessionWrapper {
      */
     val rawParams = if (config.isLocalTesting) {
       //      config.buildLocalOverwatchParams()
-//      val synthArgs = config.buildLocalOverwatchParams()
-//      mapper.readValue[OverwatchParams](synthArgs)
+      //      val synthArgs = config.buildLocalOverwatchParams()
+      //      mapper.readValue[OverwatchParams](synthArgs)
       mapper.readValue[OverwatchParams](overwatchArgs)
     } else {
       logger.log(Level.INFO, "Validating Input Parameters")
@@ -199,6 +225,16 @@ class Initializer(config: Config) extends SparkSessionWrapper {
 
     val overwatchFriendlyName = rawParams.workspaceFriendlyName.getOrElse(config.organizationId)
     config.setworkspaceFriendlyName(overwatchFriendlyName)
+
+    /**
+     * PVC: HARD OVERRIDE FOR PVC
+     * Each time PVC deploys a newer version the derived organization_id changes due to the load balancer id
+     * and/or URL to access the workspace changes. There are no identifiable, equal values that can be found
+     * between one deployment and the next. To resolve this, PVC customers will be REQUIRED to provide a canonical
+     * name for each workspace (i.e. workspaceFriendlyName) to provide consistency across deployments.
+     */
+    if (isPVC) pvcOverrideOrganizationId
+
     val overwatchScope = rawParams.overwatchScope.getOrElse(Seq("all"))
     val tokenSecret = rawParams.tokenSecret
     // TODO -- PRIORITY -- If data target is null -- default table gets dbfs:/null
@@ -456,12 +492,12 @@ object Initializer extends SparkSessionWrapper {
    * and checks for avoidable issues. The initializer is also responsible for identifying any errors in the
    * configuration that can be identified before the runs begins to enable fail fast.
    *
-   * @param overwatchArgs      Json string of args -- When passing into args in Databricks job UI, the json string must
-   *                  be passed in as an escaped Json String. Use JsonUtils in Tools to build and extract the string
-   *                  to be used here.
-   * @param debugFlag manual Boolean setter to enable the debug flag. This is different than the log4j DEBUG Level
-   *                  When setting this to true it does enable the log4j DEBUG level but throughout the code there
-   *                  is more robust output when debug is enabled.
+   * @param overwatchArgs Json string of args -- When passing into args in Databricks job UI, the json string must
+   *                      be passed in as an escaped Json String. Use JsonUtils in Tools to build and extract the string
+   *                      to be used here.
+   * @param debugFlag     manual Boolean setter to enable the debug flag. This is different than the log4j DEBUG Level
+   *                      When setting this to true it does enable the log4j DEBUG level but throughout the code there
+   *                      is more robust output when debug is enabled.
    * @return
    */
   def apply(overwatchArgs: String, debugFlag: Boolean = false): Workspace = {

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Initializer.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Initializer.scala
@@ -197,6 +197,8 @@ class Initializer(config: Config) extends SparkSessionWrapper {
     config.setInputConfig(rawParams)
 
 
+    val overwatchFriendlyName = rawParams.workspaceFriendlyName.getOrElse(config.organizationId)
+    config.setworkspaceFriendlyName(overwatchFriendlyName)
     val overwatchScope = rawParams.overwatchScope.getOrElse(Seq("all"))
     val tokenSecret = rawParams.tokenSecret
     // TODO -- PRIORITY -- If data target is null -- default table gets dbfs:/null

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTable.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTable.scala
@@ -33,6 +33,7 @@ case class PipelineTable(
                           enableSchemaMerge: Boolean = true,
                           withCreateDate: Boolean = true,
                           withOverwatchRunID: Boolean = true,
+                          withWorkspaceFriendlyName: Boolean = true,
                           isTemp: Boolean = false,
                           checkpointPath: Option[String] = None,
                           masterSchema: Option[StructType] = None

--- a/src/main/scala/com/databricks/labs/overwatch/utils/Config.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/utils/Config.scala
@@ -16,6 +16,7 @@ class Config() {
   private var _debugFlag: Boolean = false
   private var _overwatchSchemaVersion = "0.420"
   private var _organizationId: String = _
+  private var _workspaceFriendlyName: String = _
   private var _databaseName: String = _
   private var _databaseLocation: String = _
   private var _etlDataPathPrefix: String = _
@@ -56,6 +57,8 @@ class Config() {
   def debugFlag: Boolean = _debugFlag
 
   def organizationId: String = _organizationId
+
+  def workspaceFriendlyName: String = _workspaceFriendlyName
 
   def cloudProvider: String = _cloudProvider
 
@@ -240,10 +243,21 @@ class Config() {
   }
 
   private[overwatch] def setOrganizationId(value: String): this.type = {
-    if (debugFlag) println(s"organization ID set to ${value}")
+    val msg = s"organization ID set to $value"
+    logger.log(Level.INFO, msg)
+    if (debugFlag) println(msg)
     _organizationId = value
     this
   }
+
+  private[overwatch] def setworkspaceFriendlyName(value: String): this.type = {
+    val msg = s"workspaceFriendlyName set to $value"
+    logger.log(Level.INFO, msg)
+    if (debugFlag) println(msg)
+    _workspaceFriendlyName = value
+    this
+  }
+
   private def setApiEnv(value: ApiEnv): this.type = {
     _apiEnv = value
     this

--- a/src/main/scala/com/databricks/labs/overwatch/utils/Config.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/utils/Config.scala
@@ -17,6 +17,7 @@ class Config() {
   private var _overwatchSchemaVersion = "0.420"
   private var _organizationId: String = _
   private var _workspaceFriendlyName: String = _
+  private var _isPVC: Boolean = false
   private var _databaseName: String = _
   private var _databaseLocation: String = _
   private var _etlDataPathPrefix: String = _
@@ -59,6 +60,8 @@ class Config() {
   def organizationId: String = _organizationId
 
   def workspaceFriendlyName: String = _workspaceFriendlyName
+
+  def isPVC: Boolean = _isPVC
 
   def cloudProvider: String = _cloudProvider
 
@@ -255,6 +258,11 @@ class Config() {
     logger.log(Level.INFO, msg)
     if (debugFlag) println(msg)
     _workspaceFriendlyName = value
+    this
+  }
+
+  private[overwatch] def setIsPVC(value: Boolean): this.type = {
+    _isPVC = value
     this
   }
 

--- a/src/main/scala/com/databricks/labs/overwatch/utils/Structures.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/utils/Structures.scala
@@ -81,7 +81,8 @@ case class OverwatchParams(auditLogConfig: AuditLogConfig,
                            maxDaysToLoad: Int = 60,
                            databricksContractPrices: DatabricksContractPrices = DatabricksContractPrices(),
                            primordialDateString: Option[String] = None,
-                           intelligentScaling: IntelligentScaling = IntelligentScaling()
+                           intelligentScaling: IntelligentScaling = IntelligentScaling(),
+                           workspaceFriendlyName: Option[String]
                           )
 
 case class ParsedConfig(

--- a/src/test/scala/com/databricks/labs/overwatch/ParamDeserializerTest.scala
+++ b/src/test/scala/com/databricks/labs/overwatch/ParamDeserializerTest.scala
@@ -21,7 +21,7 @@ class ParamDeserializerTest extends AnyFunSpec {
         |"maxDaysToLoad":60,
         |"databricksContractPrices":{"interactiveDBUCostUSD":0.55,"automatedDBUCostUSD":0.15, "sqlComputeDBUCostUSD":0.22, "jobsLightDBUCostUSD":0.1},
         |"intelligentScaling":{"enabled":false, "minimumCores":4 , "maximumCores":512 , "coeff":1.0},
-        |"workspaceFriendlyName":{"myTestWorkspace"}}
+        |"workspaceFriendlyName":"myTestWorkspace"}
         |""".stripMargin
 
       val paramModule: SimpleModule = new SimpleModule()

--- a/src/test/scala/com/databricks/labs/overwatch/ParamDeserializerTest.scala
+++ b/src/test/scala/com/databricks/labs/overwatch/ParamDeserializerTest.scala
@@ -20,7 +20,8 @@ class ParamDeserializerTest extends AnyFunSpec {
         |"overwatchScope":["audit","accounts","jobs","sparkEvents","clusters","clusterEvents","notebooks","pools"],
         |"maxDaysToLoad":60,
         |"databricksContractPrices":{"interactiveDBUCostUSD":0.55,"automatedDBUCostUSD":0.15, "sqlComputeDBUCostUSD":0.22, "jobsLightDBUCostUSD":0.1},
-        |"intelligentScaling":{"enabled":false, "minimumCores":4 , "maximumCores":512 , "coeff":1.0}}
+        |"intelligentScaling":{"enabled":false, "minimumCores":4 , "maximumCores":512 , "coeff":1.0},
+        |"workspaceFriendlyName":{"myTestWorkspace"}}
         |""".stripMargin
 
       val paramModule: SimpleModule = new SimpleModule()
@@ -46,7 +47,8 @@ class ParamDeserializerTest extends AnyFunSpec {
         60,
         DatabricksContractPrices(),
         None,
-        IntelligentScaling()
+        IntelligentScaling(),
+        Some("myTestWorkspace")
       )
       assertResult(expected)(mapper.readValue[OverwatchParams](incomplete))
 


### PR DESCRIPTION
closes #262 
closes #234 

Allows users to customize the name of their workspace through the Overwatch config. A new column will appear in each Overwatch table called `Workspace_Name` which will mirror the name. If not configured it defaults to organization_id.

Still need to add support for PVC to switch organization_id to this ... looking into best way to do that now.