### PR TITLE
Clsf jrcp fill dup fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "overwatch"
 
 organization := "com.databricks.labs"
 
-version := "0.6.1.0"
+version := "0.6.1.1"
 
 scalaVersion := "2.12.12"
 scalacOptions ++= Seq("-Xmax-classfile-name", "78")

--- a/src/main/scala/com/databricks/labs/overwatch/env/Database.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Database.scala
@@ -150,6 +150,8 @@ class Database(config: Config) extends SparkSessionWrapper {
          |""".stripMargin)
     df.write.format("delta").save(dfTempPath)
 
+    spark.conf.set("spark.sql.files.maxPartitionBytes", 1024 * 1024 * 16) // maximize parallelism on re-read and let
+    // AQE bring it back down
     spark.read.format("delta").load(dfTempPath)
   }
 

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Gold.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Gold.scala
@@ -135,7 +135,9 @@ class Gold(_workspace: Workspace, _database: Database, _config: Config)
         GoldTargets.sparkJobTarget.asIncrementalDF(jobRunCostPotentialFactModule, GoldTargets.sparkJobTarget.incrementalColumns, 2),
         GoldTargets.sparkTaskTarget.asIncrementalDF(jobRunCostPotentialFactModule, GoldTargets.sparkTaskTarget.incrementalColumns, 2),
         jobRunCostPotentialFactModule.fromTime,
-        jobRunCostPotentialFactModule.untilTime
+        jobRunCostPotentialFactModule.untilTime,
+        GoldTargets.jobRunCostPotentialFactTarget.keys,
+        GoldTargets.jobRunCostPotentialFactTarget.incrementalColumns
       )),
     append(GoldTargets.jobRunCostPotentialFactTarget)
   )

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Gold.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Gold.scala
@@ -135,9 +135,7 @@ class Gold(_workspace: Workspace, _database: Database, _config: Config)
         GoldTargets.sparkJobTarget.asIncrementalDF(jobRunCostPotentialFactModule, GoldTargets.sparkJobTarget.incrementalColumns, 2),
         GoldTargets.sparkTaskTarget.asIncrementalDF(jobRunCostPotentialFactModule, GoldTargets.sparkTaskTarget.incrementalColumns, 2),
         jobRunCostPotentialFactModule.fromTime,
-        jobRunCostPotentialFactModule.untilTime,
-        GoldTargets.jobRunCostPotentialFactTarget.keys,
-        GoldTargets.jobRunCostPotentialFactTarget.incrementalColumns
+        jobRunCostPotentialFactModule.untilTime
       )),
     append(GoldTargets.jobRunCostPotentialFactTarget)
   )

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/GoldTransforms.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/GoldTransforms.scala
@@ -351,7 +351,9 @@ trait GoldTransforms extends SparkSessionWrapper {
                                               sparkJobLag2D: DataFrame,
                                               sparkTaskLag2D: DataFrame,
                                               fromTime: TimeTypes,
-                                              untilTime: TimeTypes
+                                              untilTime: TimeTypes,
+                                              jrcpKeys: Array[String],
+                                              jrcpIncrementalFields: Array[String]
                                             )(jrGoldLag30D: DataFrame): DataFrame = {
 
     val clusterPotentialWCosts = if (clsfLag90D.isEmpty) {
@@ -641,11 +643,13 @@ trait GoldTransforms extends SparkSessionWrapper {
         )
         .drop("db_job_id", "db_id_in_job", "orgId")
         .withColumn("job_run_cluster_util", round(('spark_task_runtime_H / 'worker_potential_core_H), 4))
+        .dropDupsByKey(jrcpKeys, jrcpIncrementalFields) // ensure no dups by key or gold merge can break
     } else {
       jobRunCostPotential
         .withColumn("spark_task_runtimeMS", lit(null).cast("long"))
         .withColumn("spark_task_runtime_H", lit(null).cast("double"))
         .withColumn("job_run_cluster_util", lit(null).cast("double"))
+        .dropDupsByKey(jrcpKeys, jrcpIncrementalFields) // ensure no dups by key or gold merge can break
     }
 
 

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/GoldTransforms.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/GoldTransforms.scala
@@ -106,7 +106,8 @@ trait GoldTransforms extends SparkSessionWrapper {
       'requestDetails.alias("request_detail"),
       'timeDetails.alias("time_detail")
     )
-    jobRunsLag30D.select(jobRunCols: _*)
+    jobRunsLag30D
+      .select(jobRunCols: _*)
   }
 
   protected def buildNotebook()(df: DataFrame): DataFrame = {
@@ -351,9 +352,7 @@ trait GoldTransforms extends SparkSessionWrapper {
                                               sparkJobLag2D: DataFrame,
                                               sparkTaskLag2D: DataFrame,
                                               fromTime: TimeTypes,
-                                              untilTime: TimeTypes,
-                                              jrcpKeys: Array[String],
-                                              jrcpIncrementalFields: Array[String]
+                                              untilTime: TimeTypes
                                             )(jrGoldLag30D: DataFrame): DataFrame = {
 
     val clusterPotentialWCosts = if (clsfLag90D.isEmpty) {
@@ -643,13 +642,11 @@ trait GoldTransforms extends SparkSessionWrapper {
         )
         .drop("db_job_id", "db_id_in_job", "orgId")
         .withColumn("job_run_cluster_util", round(('spark_task_runtime_H / 'worker_potential_core_H), 4))
-        .dropDupsByKey(jrcpKeys, jrcpIncrementalFields) // ensure no dups by key or gold merge can break
     } else {
       jobRunCostPotential
         .withColumn("spark_task_runtimeMS", lit(null).cast("long"))
         .withColumn("spark_task_runtime_H", lit(null).cast("double"))
         .withColumn("job_run_cluster_util", lit(null).cast("double"))
-        .dropDupsByKey(jrcpKeys, jrcpIncrementalFields) // ensure no dups by key or gold merge can break
     }
 
 

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/GoldTransforms.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/GoldTransforms.scala
@@ -286,7 +286,8 @@ trait GoldTransforms extends SparkSessionWrapper {
         "left")
       .drop("activeFrom", "activeUntil", "activeFromEpochMillis", "activeUntilEpochMillis", "activeFromDate", "activeUntilDate", "worker_orgid", "node_type_id_lookup")
       // filling data is critical here to ensure jrcp dups don't occur
-      .fillMeta(clusterPotMetaToFill, clusterPotKeys, clusterPotIncrementals) // scan back then forward to fill all
+      // using noise generators to fill with two passes to reduce skew
+      .fillMeta(clusterPotMetaToFill, clusterPotKeys, clusterPotIncrementals, noiseBuckets = getTotalCores) // scan back then forward to fill all
 
     val workerPotentialCoreS = when('databricks_billable, $"workerSpecs.vCPUs" * 'current_num_workers * 'uptime_in_state_S).otherwise(lit(0))
     val driverDBUs = when('databricks_billable, $"driverSpecs.Hourly_DBUs" * 'uptime_in_state_H).otherwise(lit(0)).alias("driver_dbus")

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Initializer.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Initializer.scala
@@ -218,7 +218,7 @@ class Initializer(config: Config) extends SparkSessionWrapper {
    * @param etlTargetPath target path for all overwatch data
    */
   private def prepAndSetTempWorkingDir(tempPath: String, etlTargetPath: String): Unit = {
-    val defaultTempPath = s"$etlTargetPath/tempWorkingDir/${config.organizationId}"
+    val defaultTempPath = s"$etlTargetPath/tempworkingdir/${config.organizationId}"
     val workspaceTempWorkingDir = if (tempPath == "") { // default null string
       defaultTempPath
     }

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineFunctions.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineFunctions.scala
@@ -8,6 +8,7 @@ import org.apache.spark.sql.expressions.{Window, WindowSpec}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
+import TransformFunctions._
 
 import java.io.{PrintWriter, StringWriter}
 import java.net.URI
@@ -161,7 +162,7 @@ object PipelineFunctions {
 
     var mutationDF = df
     mutationDF = if (target.zOrderBy.nonEmpty) {
-      TransformFunctions.moveColumnsToFront(mutationDF, target.zOrderBy ++ target.statsColumns)
+      mutationDF.moveColumnsToFront(target.zOrderBy ++ target.statsColumns)
     } else mutationDF
 
    val targetShufflePartitions = if (!target.tableFullName.toLowerCase.endsWith("_bronze")) {

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTable.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineTable.scala
@@ -21,6 +21,7 @@ case class PipelineTable(
                           incrementalColumns: Array[String] = Array(),
                           format: String = "delta", // TODO -- Convert to Enum
                           private val _mode: WriteMode = WriteMode.append,
+                          private val _permitDuplicateKeys: Boolean = true,
                           private val _databaseName: String = "default",
                           autoOptimize: Boolean = false,
                           autoCompact: Boolean = false,
@@ -81,6 +82,8 @@ case class PipelineTable(
       WriteMode.append
     } else _mode
   }
+
+  def permitDuplicateKeys: Boolean = if (writeMode == WriteMode.merge) false else _permitDuplicateKeys
 
   private[overwatch] def applySparkOverrides(updates: Map[String, String] = Map()): Unit = {
 

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala
@@ -220,6 +220,8 @@ class Silver(_workspace: Workspace, _database: Database, _config: Config)
   lazy private val appendJobStatusProcess = ETLDefinition(
     BronzeTargets.auditLogsTarget.asIncrementalDF(jobStatusModule, BronzeTargets.auditLogsTarget.incrementalColumns),
     Seq(
+
+
       dbJobsStatusSummary(
         BronzeTargets.jobsSnapshotTarget,
         jobStatusModule.isFirstRun,

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/TransformFunctions.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/TransformFunctions.scala
@@ -222,6 +222,24 @@ object TransformFunctions {
     }
 
     /**
+     * remove dups via a window
+     * @param keys seq of keys for the df
+     * @param incrementalFields seq of incremental fields for the df
+     * @return
+     */
+    def dropDupsByKey(
+                     keys: Seq[String],
+                     incrementalFields: Seq[String]
+                     ): DataFrame = {
+      val w = Window.partitionBy(keys map col: _*).orderBy(incrementalFields map col: _*)
+      df
+        .withColumn("rnk", rank().over(w))
+        .withColumn("rn", row_number().over(w))
+        .filter(col("rnk") === 1  && col("rn") === 1)
+        .drop("rnk", "rn")
+    }
+
+    /**
      * Supports strings, numericals, booleans. Defined keys don't contain any other types thus this function should
      * ensure no nulls present for keys
      * @return

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/TransformFunctions.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/TransformFunctions.scala
@@ -227,7 +227,7 @@ object TransformFunctions {
      * @param incrementalFields seq of incremental fields for the df
      * @return
      */
-    def dropDupsByKey(
+    def dedupByKey(
                      keys: Seq[String],
                      incrementalFields: Seq[String]
                      ): DataFrame = {

--- a/src/main/scala/com/databricks/labs/overwatch/utils/SchemaScrubber.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/utils/SchemaScrubber.scala
@@ -143,7 +143,8 @@ object SchemaScrubber {
 
   private val _defaultSanitizationRules: List[SanitizeRule] = List[SanitizeRule](
     SanitizeRule("\\s", ""),
-    SanitizeRule("[^a-zA-Z0-9]", "_")
+    SanitizeRule("[^a-zA-Z0-9]", "_"),
+    SanitizeRule("_UNIQUESUFFIX_", "_UNIQUESUFFIX__")
   )
 
   private val _noExceptions: Array[SanitizeFieldException] = Array()

--- a/src/main/scala/com/databricks/labs/overwatch/utils/Upgrade.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/utils/Upgrade.scala
@@ -9,6 +9,7 @@ import org.apache.log4j.{Level, Logger}
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{Column, DataFrame, Dataset}
+import TransformFunctions._
 
 import java.util.concurrent.{ConcurrentHashMap, ForkJoinPool}
 import scala.collection.JavaConverters._
@@ -1074,10 +1075,9 @@ object Upgrade extends SparkSessionWrapper {
           if (sparkEventsSchema.fields.exists(f => fieldsRequiringRebuild.contains(f.name))) {
             logger.info(s"Beginning full rebuild of $targetName table. This could take some time. Recommend " +
               s"monitoring of cluster size and ensure autoscaling enabled.")
-            TransformFunctions.moveColumnsToFront(
-              sparkEventsBronzeDF.drop(fieldsRequiringRebuild: _*),
-              statsColumns
-            )
+            sparkEventsBronzeDF
+              .drop(fieldsRequiringRebuild: _*)
+              .moveColumnsToFront(statsColumns)
               .write.format("delta")
               .partitionBy(partitionByCols: _*)
               .mode("overwrite").option("overwriteSchema", "true")

--- a/src/test/scala/com/databricks/labs/overwatch/pipeline/TransformFunctionsTest.scala
+++ b/src/test/scala/com/databricks/labs/overwatch/pipeline/TransformFunctionsTest.scala
@@ -6,6 +6,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.types._
 import org.scalatest.funspec.AnyFunSpec
+import TransformFunctions._
 
 import java.sql.{Date, Timestamp}
 import java.time.Instant
@@ -69,7 +70,7 @@ class TransformFunctionsTest extends AnyFunSpec with DataFrameComparer with Spar
     it("should removeNullCols") {
       val sourceData = sc.parallelize(Seq(Row("jobs", null, Row("t1", 1)),Row("non-jobs", null, Row("t2", 2))))
       val sourceDF = spark.createDataFrame(sourceData, schema)
-      val (_, df) = TransformFunctions.removeNullCols(sourceDF)
+      val df = sourceDF.cullNull
       assertResult("`serviceName` STRING,`requestParams` STRUCT<`par1`: STRING, `par2`: INT>")(df.schema.toDDL)
       assertResult(2)(df.count())
       val first = df.first()
@@ -152,7 +153,7 @@ class TransformFunctionsTest extends AnyFunSpec with DataFrameComparer with Spar
     it("should moveColumnsToFront") {
       assertResult(Seq("field3", "field2", "field1")){
         val df = spark.createDataFrame(Seq((1,2,3))).toDF("field1", "field2", "field3")
-        TransformFunctions.moveColumnsToFront(df, Array("field3", "field2")).schema.names.toSeq
+        df.moveColumnsToFront(Array("field3", "field2")).schema.names.toSeq
       }
     }
   }


### PR DESCRIPTION
still seeing stray records in some customers that are resulting in dups (around 4 or 6) for a customer during historical load. Still unable to pinpoint where they are coming from but have confirmed that they are in fact dups in all cases.

The steps taken in this PR are to ensure the metadata is filled in all cases possible (i.e. to ensure that one record doesn't have metadata like "cluster_name" while the other doesn't) and force ensure no dups make it through to target merge as it fails the module if that happens.

closes #369 
closes #387 
closes #388
closes #405 