### PR TITLE
In ApiCallV2 removed the exception and sending empty dataframe

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/ApiCallV2.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/ApiCallV2.scala
@@ -454,11 +454,15 @@ class ApiCallV2(apiEnv: ApiEnv) extends SparkSessionWrapper {
 
     }
     if (apiResultDF.columns.length == 0) {
-      val errMsg = s"API CALL Resulting DF is empty BUT no errors detected, progressing module. " +
-        s"Details Below:\n$buildGenericErrorMessage"
-      throw new ApiCallEmptyResponse(errMsg, true)
+      val errMsg =
+        s"""API CALL Resulting DF is empty BUT no errors detected, progressing module.
+           |Details Below:\n$buildGenericErrorMessage""".stripMargin
+      println(errMsg)
+      logger.error(errMsg)
+      spark.emptyDataFrame
+    }else {
+      extrapolateSupportedStructure(apiResultDF)
     }
-    extrapolateSupportedStructure(apiResultDF)
   }
 
 

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -105,11 +105,21 @@ class Workspace(config: Config) extends SparkSessionWrapper {
         .withColumn("organization_id", lit(config.organizationId))
     }
     catch {
-      case e: ApiCallEmptyResponse =>
-        val message = s"Exceotion in reading pool list ${e}"
+      /**In case if there is no cluster pools available in workspace .asDF() call throws ApiCallEmptyResponse exception.
+       * Handle the ApiCallEmptyResponse exception and move on to the rest of the modules
+       */
+      case emptyResponseError: ApiCallEmptyResponse =>
+        val message = s"Exceotion in reading pool list ${emptyResponseError}"
         println(message)
         logger.error(message)
         spark.emptyDataFrame
+
+      /**
+       * Any other exception other than ApiCallEmptyResponse exception. raise the exception and exit the process
+       */
+      case ex: Exception =>
+        logger.error(ex)
+        throw new Exception(ex)
     }
   }
 

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -106,20 +106,14 @@ class Workspace(config: Config) extends SparkSessionWrapper {
     }
     catch {
       /**In case if there is no cluster pools available in workspace .asDF() call throws ApiCallEmptyResponse exception.
-       * Handle the ApiCallEmptyResponse exception and move on to the rest of the modules
+       * Handle the ApiCallEmptyResponse exception and move on to the rest of the modules.
+       * Not handling any other exceptions.
        */
       case emptyResponseError: ApiCallEmptyResponse =>
         val message = s"Exceotion in reading pool list ${emptyResponseError}"
         println(message)
         logger.error(message)
         spark.emptyDataFrame
-
-      /**
-       * Any other exception other than ApiCallEmptyResponse exception. raise the exception and exit the process
-       */
-      case ex: Exception =>
-        logger.error(ex)
-        throw new Exception(ex)
     }
   }
 

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -98,24 +98,10 @@ class Workspace(config: Config) extends SparkSessionWrapper {
    */
   def getPoolsDF: DataFrame = {
     val poolsEndpoint = "instance-pools/list"
-    val apiResponse = ApiCallV2(config.apiEnv, poolsEndpoint)
-        .execute()
-    try{
-    apiResponse
-        .asDF()
-        .withColumn("organization_id", lit(config.organizationId))
-    }
-    catch {
-      /**In case if there is no cluster pools available in workspace .asDF() call throws ApiCallEmptyResponse exception.
-       * Handle the ApiCallEmptyResponse exception and move on to the rest of the modules.
-       * Not handling any other exceptions.
-       */
-      case emptyResponseError: ApiCallEmptyResponse =>
-        val message = s"Exceotion in reading pool list ${emptyResponseError}"
-        println(message)
-        logger.error(message)
-        spark.emptyDataFrame.withColumn("organization_id", lit(config.organizationId))
-    }
+    ApiCallV2(config.apiEnv,poolsEndpoint)
+      .execute()
+      .asDF()
+      .withColumn("organization_id", lit(config.organizationId))
   }
 
   /**

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -98,10 +98,19 @@ class Workspace(config: Config) extends SparkSessionWrapper {
    */
   def getPoolsDF: DataFrame = {
     val poolsEndpoint = "instance-pools/list"
-    ApiCallV2(config.apiEnv,poolsEndpoint)
-      .execute()
-      .asDF()
-      .withColumn("organization_id", lit(config.organizationId))
+    try {
+      ApiCallV2(config.apiEnv, poolsEndpoint)
+        .execute()
+        .asDF()
+        .withColumn("organization_id", lit(config.organizationId))
+    }
+    catch {
+      case e: Exception =>
+        val message = s"Exceotion in reading pool list ${e}"
+        println(message)
+        logger.error(message)
+        spark.emptyDataFrame
+    }
   }
 
   /**

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -105,7 +105,7 @@ class Workspace(config: Config) extends SparkSessionWrapper {
         .withColumn("organization_id", lit(config.organizationId))
     }
     catch {
-      case e: Exception =>
+      case e: ApiCallEmptyResponse =>
         val message = s"Exceotion in reading pool list ${e}"
         println(message)
         logger.error(message)

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -98,9 +98,10 @@ class Workspace(config: Config) extends SparkSessionWrapper {
    */
   def getPoolsDF: DataFrame = {
     val poolsEndpoint = "instance-pools/list"
-    try {
-      ApiCallV2(config.apiEnv, poolsEndpoint)
+    val apiResponse = ApiCallV2(config.apiEnv, poolsEndpoint)
         .execute()
+    try{
+    apiResponse
         .asDF()
         .withColumn("organization_id", lit(config.organizationId))
     }
@@ -113,7 +114,7 @@ class Workspace(config: Config) extends SparkSessionWrapper {
         val message = s"Exceotion in reading pool list ${emptyResponseError}"
         println(message)
         logger.error(message)
-        spark.emptyDataFrame
+        spark.emptyDataFrame.withColumn("organization_id", lit(config.organizationId))
     }
   }
 


### PR DESCRIPTION
closes #461
Negative testing --> With existing code bronze process is failing and terminating without executing the whole scope.
Unit testing --> With modified code bronze process is completed even if there is no pool available.

out of scope
I have not tested the data(tables generated by overwatch) after the code change.