### PR TITLE
Add check for if is unity catalog in the database location validation.

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Initializer.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Initializer.scala
@@ -394,7 +394,7 @@ class Initializer(config: Config) extends SparkSessionWrapper {
       val dbMeta = spark.sessionState.catalog.getDatabaseMetadata(dbName)
       val dbProperties = dbMeta.properties
       val existingDBLocation = dbMeta.locationUri.toString
-      if (existingDBLocation != dbLocation) {
+      if (existingDBLocation != dbLocation && dbProperties.getOrElse("IS_UNITY_CATALOG", "FALSE") == "FALSE") {
         switch = false
         throw new BadConfigException(s"The DB: $dbName exists " +
           s"at location $existingDBLocation which is different than the location entered in the config. Ensure " +


### PR DESCRIPTION
[https://github.com/databrickslabs/overwatch/issues/500](url)

There is no way to add a location property to a database in unity catalog and will always fail when validating whether the existing database location equals the specified location.

This PR will bypass that test if you add a `IS_UNITY_CATALOG ` property to the UC database 