### PR TITLE
537 sql history parallelize

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "overwatch"
 
 organization := "com.databricks.labs"
 
-version := "0.7.0.0"
+version := "0.7.0.1"
 
 scalaVersion := "2.12.12"
 scalacOptions ++= Seq("-Xmax-classfile-name", "78")

--- a/src/main/scala/com/databricks/labs/overwatch/ApiCallV2.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/ApiCallV2.scala
@@ -501,6 +501,7 @@ class ApiCallV2(apiEnv: ApiEnv) extends SparkSessionWrapper {
       val response = getResponse
       responseCodeHandler(response)
       _apiResponseArray.add(response.body)
+//      println(s"""response.body----${response.body}""")
       if (apiMeta.storeInTempLocation) {
         accumulator.add(1)
         if (apiEnv.successBatchSize <= _apiResponseArray.size()) { //Checking if its right time to write the batches into persistent storage

--- a/src/main/scala/com/databricks/labs/overwatch/ApiCallV2.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/ApiCallV2.scala
@@ -501,7 +501,6 @@ class ApiCallV2(apiEnv: ApiEnv) extends SparkSessionWrapper {
       val response = getResponse
       responseCodeHandler(response)
       _apiResponseArray.add(response.body)
-//      println(s"""response.body----${response.body}""")
       if (apiMeta.storeInTempLocation) {
         accumulator.add(1)
         if (apiEnv.successBatchSize <= _apiResponseArray.size()) { //Checking if its right time to write the batches into persistent storage

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -202,8 +202,12 @@ class Workspace(config: Config) extends SparkSessionWrapper {
         ).executeMultiThread()
 
         synchronized {
-          println(s"""apiObj......${apiObj}""")
-          apiResponseArray.addAll(apiObj)
+          apiObj.forEach(
+            obj=>if(obj.contains("res")){
+              apiResponseArray.add(obj)
+            }
+          )
+//          apiResponseArray.addAll(apiObj)
           if (apiResponseArray.size() >= config.apiEnv.successBatchSize) {
             PipelineFunctions.writeMicroBatchToTempLocation(tmpSqlQueryHistorySuccessPath, apiResponseArray.toString)
             apiResponseArray = Collections.synchronizedList(new util.ArrayList[String]())

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -163,7 +163,6 @@ class Workspace(config: Config) extends SparkSessionWrapper {
     val acc = sc.longAccumulator("sqlQueryHistoryAccumulator")
     var apiResponseArray = Collections.synchronizedList(new util.ArrayList[String]())
     var apiErrorArray = Collections.synchronizedList(new util.ArrayList[String]())
-//    var responseCounter = 0
     val apiResponseCounter = Collections.synchronizedList(new util.ArrayList[Int]())
     implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(config.apiEnv.threadPoolSize))
     val tmpSqlQueryHistorySuccessPath = s"${config.tempWorkingDir}/sqlqueryhistory_silver/${System.currentTimeMillis()}"
@@ -208,7 +207,6 @@ class Workspace(config: Config) extends SparkSessionWrapper {
               apiResponseArray.add(obj)
             }
           )
-//          apiResponseArray.addAll(apiObj)
           if (apiResponseArray.size() >= config.apiEnv.successBatchSize) {
             PipelineFunctions.writeMicroBatchToTempLocation(tmpSqlQueryHistorySuccessPath, apiResponseArray.toString)
             apiResponseArray = Collections.synchronizedList(new util.ArrayList[String]())
@@ -217,7 +215,6 @@ class Workspace(config: Config) extends SparkSessionWrapper {
       }
       future.onComplete {
         case Success(_) =>
-//          responseCounter = responseCounter + 1
           apiResponseCounter.add(1)
 
         case Failure(e) =>
@@ -231,7 +228,6 @@ class Workspace(config: Config) extends SparkSessionWrapper {
             }
             logger.log(Level.ERROR, "Future failure message: " + e.getMessage, e)
           }
-//          responseCounter = responseCounter + 1
           apiResponseCounter.add(1)
       }
       fromTimeMs = fromTimeMs+(1000*60*60)

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -201,6 +201,7 @@ class Workspace(config: Config) extends SparkSessionWrapper {
         ).executeMultiThread()
 
         synchronized {
+          println(s"""apiObj......${apiObj}""")
           apiResponseArray.addAll(apiObj)
           if (apiResponseArray.size() >= config.apiEnv.successBatchSize) {
             PipelineFunctions.writeMicroBatchToTempLocation(tmpSqlQueryHistorySuccessPath, apiResponseArray.toString)

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -166,6 +166,7 @@ class Workspace(config: Config) extends SparkSessionWrapper {
     var responseCounter = 0
     implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(config.apiEnv.threadPoolSize))
     val tmpSqlQueryHistorySuccessPath = s"${config.tempWorkingDir}/sqlqueryhistory_silver/${System.currentTimeMillis()}"
+    val tmpSqlQueryHistoryErrorPath = s"${config.tempWorkingDir}/errors/sqlqueryhistory_silver/${System.currentTimeMillis()}"
     val untilTimeMs = untilTime.asUnixTimeMilli
     var fromTimeMs = fromTime.asUnixTimeMilli - (1000*60*60*24*2)  //subtracting 2 days for running query merge
     val finalResponseCount = scala.math.ceil((untilTimeMs - fromTimeMs).toDouble/(1000*60*60)) // Total no. of API Calls
@@ -218,7 +219,7 @@ class Workspace(config: Config) extends SparkSessionWrapper {
             synchronized {
               apiErrorArray.add(e.getMessage)
               if (apiErrorArray.size() >= config.apiEnv.errorBatchSize) {
-                PipelineFunctions.writeMicroBatchToTempLocation(tmpSqlQueryHistorySuccessPath, apiErrorArray.toString)
+                PipelineFunctions.writeMicroBatchToTempLocation(tmpSqlQueryHistoryErrorPath, apiErrorArray.toString)
                 apiErrorArray = Collections.synchronizedList(new util.ArrayList[String]())
               }
             }

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala
@@ -315,7 +315,7 @@ class Silver(_workspace: Workspace, _database: Database, _config: Config)
 
   lazy private[overwatch] val sqlQueryHistoryModule = Module(2020, "Silver_SQLQueryHistory", this)
   lazy private val appendSqlQueryHistoryProcess = ETLDefinition(
-    workspace.getSqlQueryHistoryDF(sqlQueryHistoryModule.fromTime, sqlQueryHistoryModule.untilTime),
+    workspace.getSqlQueryHistoryParallelDF(sqlQueryHistoryModule.fromTime, sqlQueryHistoryModule.untilTime),
     Seq(enhanceSqlQueryHistory),
     append(SilverTargets.sqlQueryHistoryTarget)
   )

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala
@@ -313,7 +313,7 @@ class Silver(_workspace: Workspace, _database: Database, _config: Config)
     append(SilverTargets.notebookStatusTarget)
   )
 
-  lazy private[overwatch] val sqlQueryHistoryModule = Module(2020, "Silver_SQLQueryHistory", this)
+  lazy private[overwatch] val sqlQueryHistoryModule = Module(2020, "Silver_SQLQueryHistory", this, Array(1004))
   lazy private val appendSqlQueryHistoryProcess = ETLDefinition(
     workspace.getSqlQueryHistoryParallelDF(sqlQueryHistoryModule.fromTime, sqlQueryHistoryModule.untilTime),
     Seq(enhanceSqlQueryHistory),

--- a/src/test/scala/com/databricks/labs/overwatch/ApiCallV2Test.scala
+++ b/src/test/scala/com/databricks/labs/overwatch/ApiCallV2Test.scala
@@ -287,9 +287,11 @@ class ApiCallV2Test extends AnyFunSpec with BeforeAndAfterAll {
       val sqlQueryHistoryEndpoint = "sql/history/queries"
       val acc = sc.longAccumulator("sqlQueryHistoryAccumulator")
 //      val startTime =  "1665878400000".toLong // subtract 2 days for running query merge
-      val startTime =  "1666224000010".toLong -(1000*60*60*24)// subtract 2 days for running query merge
-      val untilTime = "1666224000010".toLong
+//      val startTime =  "1669026035073".toLong -(1000*60*60*24)// subtract 2 days for running query merge
+      val startTime =  "1669026035073".toLong
+      val untilTime = "1669112526676".toLong
       val tempWorkingDir = ""
+      println("test_started")
       val jsonQuery = Map(
         "max_results" -> "50",
         "include_metrics" -> "true",
@@ -329,10 +331,14 @@ class ApiCallV2Test extends AnyFunSpec with BeforeAndAfterAll {
       implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(apiEnv.threadPoolSize))
       val tmpSqlQueryHistorySuccessPath = "/tmp/test/"
       val tmpSqlQueryHistoryErrorPath = ""
-      val untilTimeMs = "1666182197381".toLong
+      val startTime =  "1669026035073".toLong
+      val untilTimeMs = "1669112526676".toLong
+
+//      val untilTimeMs = "1666182197381".toLong
 //      val untilTimeMs = "1662249600000".toLong
 //      var fromTimeMs = "1662249600000".toLong - (1000*60*60*24*2)  //subtracting 2 days for running query merge
-      var fromTimeMs = "1666182197381".toLong - (1000*60*60*24*2)
+//      var fromTimeMs = "1666182197381".toLong - (1000*60*60*24*2)
+      var fromTimeMs = "1669026035073".toLong
       val finalResponseCount = scala.math.ceil((untilTimeMs - fromTimeMs).toDouble/(1000*60*60)) // Total no. of API Calls
 
       while (fromTimeMs < untilTimeMs){


### PR DESCRIPTION
closes #537 
* Adding new function in workspace.scala for parallelize API call for sqlQueryHistory
* Replacing new function in Silver.scala for sqlQueryHistory