### PR TITLE
537 Prallelize sqlQueryHistory API calls

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -280,7 +280,7 @@ class Workspace(config: Config) extends SparkSessionWrapper {
           throw new Exception(e)
       }
     } else {
-      println(s"""No Data is present in temporary Path from - ${fromTimeMs} to - ${untilTimeMs}""")
+      println(s"""No Data is present in temporary path for sql/query/history from - ${fromTimeMs} to - ${untilTimeMs}""")
       spark.emptyDataFrame
     }
   }

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -280,7 +280,8 @@ class Workspace(config: Config) extends SparkSessionWrapper {
           throw new Exception(e)
       }
     } else {
-      println(s"""No Data is present in for sql/query/history from - ${fromTimeMs} to - ${untilTimeMs}""")
+      println(s"""No Data is present for sql/query/history from - ${fromTimeMs} to - ${untilTimeMs}""")
+      logger.log(Level.INFO,s"""No Data is present for sql/query/history from - ${fromTimeMs} to - ${untilTimeMs}""")
       spark.emptyDataFrame
     }
   }

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -280,7 +280,7 @@ class Workspace(config: Config) extends SparkSessionWrapper {
           throw new Exception(e)
       }
     } else {
-      println(s"""No Data is present in temporary path for sql/query/history from - ${fromTimeMs} to - ${untilTimeMs}""")
+      println(s"""No Data is present in for sql/query/history from - ${fromTimeMs} to - ${untilTimeMs}""")
       spark.emptyDataFrame
     }
   }

--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -280,7 +280,7 @@ class Workspace(config: Config) extends SparkSessionWrapper {
           throw new Exception(e)
       }
     } else {
-      println("No Data is present in temporary Path")
+      println(s"""No Data is present in temporary Path from - ${fromTimeMs} to - ${untilTimeMs}""")
       spark.emptyDataFrame
     }
   }

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala
@@ -317,9 +317,9 @@ class Silver(_workspace: Workspace, _database: Database, _config: Config)
     append(SilverTargets.notebookStatusTarget)
   )
 
-  lazy private[overwatch] val sqlQueryHistoryModule = Module(2020, "Silver_SQLQueryHistory", this)
+  lazy private[overwatch] val sqlQueryHistoryModule = Module(2020, "Silver_SQLQueryHistory", this, Array(1004))
   lazy private val appendSqlQueryHistoryProcess = ETLDefinition(
-    workspace.getSqlQueryHistoryDF(sqlQueryHistoryModule.fromTime, sqlQueryHistoryModule.untilTime),
+    workspace.getSqlQueryHistoryParallelDF(sqlQueryHistoryModule.fromTime, sqlQueryHistoryModule.untilTime),
     Seq(enhanceSqlQueryHistory),
     append(SilverTargets.sqlQueryHistoryTarget)
   )

--- a/src/test/scala/com/databricks/labs/overwatch/ApiCallV2Test.scala
+++ b/src/test/scala/com/databricks/labs/overwatch/ApiCallV2Test.scala
@@ -3,6 +3,9 @@ package com.databricks.labs.overwatch
 import com.databricks.labs.overwatch.ApiCallV2.sc
 import com.databricks.labs.overwatch.pipeline.PipelineFunctions
 import com.databricks.labs.overwatch.utils.{ApiCallFailureV2, ApiEnv}
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.lit
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.{BeforeAndAfterAll, Ignore}
 
@@ -268,6 +271,173 @@ class ApiCallV2Test extends AnyFunSpec with BeforeAndAfterAll {
       if (responseCounter != finalResponseCount) {
         throw new Exception(s"""Unable to receive all the clusters/events api responses; Api response received ${responseCounter};Api response not received ${finalResponseCount - responseCounter}""")
       }
+    }
+
+    it("test sqlHistoryDF"){
+      lazy val spark: SparkSession = {
+        SparkSession
+          .builder()
+          .master("local")
+          .appName("spark session")
+          .config("spark.sql.shuffle.partitions", "1")
+          .getOrCreate()
+      }
+      lazy val sc: SparkContext = spark.sparkContext
+      val sqlQueryHistoryEndpoint = "sql/history/queries"
+      val acc = sc.longAccumulator("sqlQueryHistoryAccumulator")
+      //      val startTime =  "1665878400000".toLong // subtract 2 days for running query merge
+      //      val startTime =  "1669026035073".toLong -(1000*60*60*24)// subtract 2 days for running query merge
+      val startTime =  "1669026035073".toLong
+      val untilTime = "1669112526676".toLong
+      val tempWorkingDir = ""
+      println("test_started")
+      val jsonQuery = Map(
+        "max_results" -> "50",
+        "include_metrics" -> "true",
+        "filter_by.query_start_time_range.start_time_ms" ->  s"$startTime",
+        "filter_by.query_start_time_range.end_time_ms" ->  s"${untilTime}"
+      )
+      ApiCallV2(
+        apiEnv,
+        sqlQueryHistoryEndpoint,
+        jsonQuery,
+        tempSuccessPath = s"${tempWorkingDir}/sqlqueryhistory_silver/${System.currentTimeMillis()}",
+        accumulator = acc
+      )
+        .execute()
+        .asDF()
+        .withColumn("organization_id", lit("1234"))
+        .show(false)
+    }
+
+    it("test sqlQueryHistoryParallel") {
+      println("test")
+      lazy val spark: SparkSession = {
+        SparkSession
+          .builder()
+          .master("local")
+          .appName("spark session")
+          .config("spark.sql.shuffle.partitions", "1")
+          .getOrCreate()
+      }
+
+      lazy val sc: SparkContext = spark.sparkContext
+      val sqlQueryHistoryEndpoint = "sql/history/queries"
+      val acc = sc.longAccumulator("sqlQueryHistoryAccumulator")
+      var apiResponseArray = Collections.synchronizedList(new util.ArrayList[String]())
+      var apiErrorArray = Collections.synchronizedList(new util.ArrayList[String]())
+      var responseCounter = 0
+      implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(apiEnv.threadPoolSize))
+      val tmpSqlQueryHistorySuccessPath = "/tmp/test/"
+      val tmpSqlQueryHistoryErrorPath = ""
+      val startTime =  "1669026035073".toLong
+      val untilTimeMs = "1669112526676".toLong
+
+      //      val untilTimeMs = "1666182197381".toLong
+      //      val untilTimeMs = "1662249600000".toLong
+      //      var fromTimeMs = "1662249600000".toLong - (1000*60*60*24*2)  //subtracting 2 days for running query merge
+      //      var fromTimeMs = "1666182197381".toLong - (1000*60*60*24*2)
+      var fromTimeMs = "1669026035073".toLong
+      val finalResponseCount = scala.math.ceil((untilTimeMs - fromTimeMs).toDouble/(1000*60*60)) // Total no. of API Calls
+
+      while (fromTimeMs < untilTimeMs){
+        val (startTime, endTime) = if ((untilTimeMs- fromTimeMs)/(1000*60*60) > 1) {
+          (fromTimeMs,
+            fromTimeMs+(1000*60*60))
+        }
+        else{
+          (fromTimeMs,
+            untilTimeMs)
+        }
+
+        //create payload for the API calls
+        val jsonQuery = Map(
+          "max_results" -> "50",
+          "include_metrics" -> "true",
+          "filter_by.query_start_time_range.start_time_ms" ->  s"$startTime", // Do we need to subtract 2 days for every API call?
+          "filter_by.query_start_time_range.end_time_ms" ->  s"$endTime"
+        )
+        /**TODO:
+         * Refactor the below code to make it more generic
+         */
+        //call future
+        val future = Future {
+          val apiObj = ApiCallV2(
+            apiEnv,
+            sqlQueryHistoryEndpoint,
+            jsonQuery,
+            tempSuccessPath = tmpSqlQueryHistorySuccessPath,
+            accumulator = acc
+          ).executeMultiThread()
+
+          synchronized {
+            apiObj.forEach(
+              obj=>if(obj.contains("res")){
+                apiResponseArray.add(obj)
+              }
+            )
+            println(apiResponseArray.toString)
+            if (apiResponseArray.size() >= apiEnv.successBatchSize) {
+              PipelineFunctions.writeMicroBatchToTempLocation(tmpSqlQueryHistorySuccessPath, apiResponseArray.toString)
+              apiResponseArray = Collections.synchronizedList(new util.ArrayList[String]())
+            }
+          }
+        }
+        future.onComplete {
+          case Success(_) =>
+            responseCounter = responseCounter + 1
+
+          case Failure(e) =>
+            if (e.isInstanceOf[ApiCallFailureV2]) {
+              synchronized {
+                apiErrorArray.add(e.getMessage)
+                if (apiErrorArray.size() >= apiEnv.errorBatchSize) {
+                  PipelineFunctions.writeMicroBatchToTempLocation(tmpSqlQueryHistoryErrorPath, apiErrorArray.toString)
+                  apiErrorArray = Collections.synchronizedList(new util.ArrayList[String]())
+                }
+              }
+
+            }
+            responseCounter = responseCounter + 1
+        }
+        fromTimeMs = fromTimeMs+(1000*60*60)
+      }
+      val timeoutThreshold = apiEnv.apiWaitingTime // 5 minutes
+      var currentSleepTime = 0
+      var accumulatorCountWhileSleeping = acc.value
+      while (responseCounter < finalResponseCount && currentSleepTime < timeoutThreshold) {
+        //As we are using Futures and running 4 threads in parallel, We are checking if all the treads has completed the execution or not.
+        // If we have not received the response from all the threads then we are waiting for 5 seconds and again revalidating the count.
+        if (currentSleepTime > 120000) //printing the waiting message only if the waiting time is more than 2 minutes.
+        {
+          println(s"""Waiting for other queued API Calls to complete; cumulative wait time ${currentSleepTime / 1000} seconds; Api response yet to receive ${finalResponseCount - responseCounter}""")
+        }
+        Thread.sleep(5000)
+        currentSleepTime += 5000
+        if (accumulatorCountWhileSleeping < acc.value) { //new API response received while waiting.
+          currentSleepTime = 0 //resetting the sleep time.
+          accumulatorCountWhileSleeping = acc.value
+        }
+      }
+      if (responseCounter != finalResponseCount) { // Checking whether all the api responses has been received or not.
+
+        throw new Exception(s"""Unable to receive all the sql/history/queries api responses; Api response received ${responseCounter};Api response not received ${finalResponseCount - responseCounter}""")
+      }
+      if (apiResponseArray.size() > 0) { //In case of response array didn't hit the batch-size as a final step we will write it to the persistent storage.
+        PipelineFunctions.writeMicroBatchToTempLocation(tmpSqlQueryHistorySuccessPath, apiResponseArray.toString)
+        apiResponseArray = Collections.synchronizedList(new util.ArrayList[String]())
+      }
+      if (apiErrorArray.size() > 0) { //In case of error array didn't hit the batch-size as a final step we will write it to the persistent storage.
+        PipelineFunctions.writeMicroBatchToTempLocation(tmpSqlQueryHistorySuccessPath, apiErrorArray.toString)
+        apiErrorArray = Collections.synchronizedList(new util.ArrayList[String]())
+      }
+
+      println(tmpSqlQueryHistorySuccessPath)
+      print(apiResponseArray.toString)
+      //      spark.read.json(tmpSqlQueryHistorySuccessPath)
+      //        .select(explode(col("res")).alias("res")).select(col("res" + ".*"))
+      //        .withColumn("organization_id", lit("123"))
+
     }
 
   }


### PR DESCRIPTION
closes #537 
* Adding new function in workspace.scala for parallelize API call for sqlQueryHistory
* Replacing new function in Silver.scala for sqlQueryHistory