### PR TITLE
Concurrent Writes - Table Lock for Parallelized Loads

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/BatchRunner.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/BatchRunner.scala
@@ -7,6 +7,7 @@ import org.apache.log4j.{Level, Logger}
 object BatchRunner extends SparkSessionWrapper {
 
   private val logger: Logger = Logger.getLogger(this.getClass)
+  SparkSessionWrapper.globalTableLock.clear()
 
   private def setGlobalDeltaOverrides(): Unit = {
     spark.conf.set("spark.databricks.delta.optimize.maxFileSize", 1024 * 1024 * 128)

--- a/src/main/scala/com/databricks/labs/overwatch/BatchRunner.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/BatchRunner.scala
@@ -7,6 +7,7 @@ import org.apache.log4j.{Level, Logger}
 object BatchRunner extends SparkSessionWrapper {
 
   private val logger: Logger = Logger.getLogger(this.getClass)
+  SparkSessionWrapper.sessionsMap.clear()
   SparkSessionWrapper.globalTableLock.clear()
 
   private def setGlobalDeltaOverrides(): Unit = {

--- a/src/main/scala/com/databricks/labs/overwatch/MultiWorkspaceDeployment.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/MultiWorkspaceDeployment.scala
@@ -365,6 +365,7 @@ class MultiWorkspaceDeployment extends SparkSessionWrapper {
     try {
       if (parallelism > 1) SparkSessionWrapper.parSessionsOn = true
       SparkSessionWrapper.sessionsMap.clear()
+      SparkSessionWrapper.globalTableLock.clear()
 
       // initialize spark overrides for global spark conf
       PipelineFunctions.setSparkOverrides(spark(globalSession = true), SparkSessionWrapper.globalSparkConfOverrides)
@@ -406,6 +407,7 @@ class MultiWorkspaceDeployment extends SparkSessionWrapper {
       case e: Exception => throw e
     } finally {
       SparkSessionWrapper.sessionsMap.clear()
+      SparkSessionWrapper.globalTableLock.clear()
     }
     println(s"""Deployment completed in sec ${(System.currentTimeMillis() - processingStartTime) / 1000}""")
   }

--- a/src/main/scala/com/databricks/labs/overwatch/env/Database.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Database.scala
@@ -13,6 +13,7 @@ import org.apache.spark.sql.{Column, DataFrame, DataFrameWriter, Row}
 import java.util
 import java.util.UUID
 import scala.annotation.tailrec
+import scala.util.Random
 
 class Database(config: Config) extends SparkSessionWrapper {
 
@@ -166,8 +167,15 @@ class Database(config: Config) extends SparkSessionWrapper {
       .map(_.name).headOption
   }
 
-  def preWriteActions(df: DataFrame, target: PipelineTable,pipelineSnapTime: Column): DataFrame =
-  {
+  /**
+   * Add metadata, cleanse duplicates, and persistBeforeWrite for perf as needed based on target
+   *
+   * @param df               original dataframe that is to be written
+   * @param target           target to which the df is to be written
+   * @param pipelineSnapTime pipelineSnapTime
+   * @return
+   */
+  private def preWriteActions(df: DataFrame, target: PipelineTable, pipelineSnapTime: Column): DataFrame = {
     var finalSourceDF: DataFrame = df
     finalSourceDF = if (target.withCreateDate) finalSourceDF.withColumn("Pipeline_SnapTS", pipelineSnapTime) else finalSourceDF
     finalSourceDF = if (target.withOverwatchRunID) finalSourceDF.withColumn("Overwatch_RunID", lit(config.runID)) else finalSourceDF
@@ -182,25 +190,32 @@ class Database(config: Config) extends SparkSessionWrapper {
 
   // TODO - refactor this write function and the writer from the target
   //  write function has gotten overly complex
-  def write(df: DataFrame, target: PipelineTable, pipelineSnapTime: Column, maxMergeScanDates: Array[String] = Array(),perWritePerformed: Boolean =  false): Boolean = {
-    var finalSourceDF: DataFrame = df
 
-    val finalDF: DataFrame = if(!perWritePerformed){
-      finalSourceDF = if (target.withCreateDate) finalSourceDF.withColumn("Pipeline_SnapTS", pipelineSnapTime) else finalSourceDF
-      finalSourceDF = if (target.withOverwatchRunID) finalSourceDF.withColumn("Overwatch_RunID", lit(config.runID)) else finalSourceDF
-      finalSourceDF = if (target.workspaceName) finalSourceDF.withColumn("workspace_name", lit(config.workspaceName)) else finalSourceDF
+  /**
+   * Write the dataframe to the target
+   *
+   * @param df                 df with data to be written
+   * @param target             target to where data should be saved
+   * @param pipelineSnapTime   pipelineSnapTime
+   * @param maxMergeScanDates  perf -- max dates to scan on a merge write. If populated this will filter the target source
+   *                           df to minimize the right-side scan.
+   * @param preWritesPerformed whether pre-write actions have already been completed prior to calling write. This is
+   *                           defaulted to false and should only be set to true in specific circumstances when
+   *                           preWriteActions was called prior to calling the write function. Typically used for
+   *                           concurrency locking.
+   * @return
+   */
+  def write(df: DataFrame, target: PipelineTable, pipelineSnapTime: Column, maxMergeScanDates: Array[String] = Array(), preWritesPerformed: Boolean = false): Unit = {
+    val finalSourceDF: DataFrame = df
 
-      // if target is to be deduped, dedup it by keys
-      finalSourceDF = if (!target.permitDuplicateKeys) finalSourceDF.dedupByKey(target.keys, target.incrementalColumns) else finalSourceDF
-      if (target.persistBeforeWrite) persistAndLoad(finalSourceDF, target) else finalSourceDF
-    }else{
+    // append metadata to source DF and cleanse as necessary
+    val finalDF = if (!preWritesPerformed) {
+      preWriteActions(finalSourceDF, target, pipelineSnapTime)
+    } else {
       finalSourceDF
     }
 
-    // apend metadata to source DF
-
-
-   // ON FIRST RUN - WriteMode is automatically overwritten to APPEND
+    // ON FIRST RUN - WriteMode is automatically overwritten to APPEND
     if (target.writeMode == WriteMode.merge) { // DELTA MERGE / UPSERT
       val deltaTarget = DeltaTable.forPath(target.tableLocation).alias("target")
       val updatesDF = finalDF.alias("updates")
@@ -273,17 +288,74 @@ class Database(config: Config) extends SparkSessionWrapper {
       logger.log(Level.INFO, s"Completed write to ${target.tableFullName}")
     }
     registerTarget(target)
-    true
   }
 
   /**
+   * Function forces the thread to sleep for some specified time.
+   * @param tableName Name of table for logging only
+   * @param minimumSeconds minimum number of seconds for which to sleep
+   * @param maxRandomSeconds max random seconds to add
+   */
+  private def coolDown(tableName: String, minimumSeconds: Long, maxRandomSeconds: Long): Unit = {
+    val rnd = new scala.util.Random
+    val number: Long = ((rnd.nextFloat() * maxRandomSeconds) + minimumSeconds).toLong * 1000L
+    logger.log(Level.INFO,"Slowing parallel writes to " + tableName + "sleeping..." + number +
+      " thread name " + Thread.currentThread().getName)
+    Thread.sleep(number)
+  }
+
+  /**
+   * Perform write retry after cooldown for legacy deployments
+   * race conditions can occur when multiple workspaces attempt to modify the schema at the same time, when this
+   * occurs, simply retry the write after some cooldown
+   * @param inputDf DF to write
+   * @param target target to where to write
+   * @param pipelineSnapTime pipelineSnapTime
+   * @param maxMergeScanDates same as write function
+   */
+  private def performRetry(inputDf: DataFrame,
+                   target: PipelineTable,
+                   pipelineSnapTime: Column,
+                   maxMergeScanDates: Array[String] = Array()): Unit = {
+    @tailrec def executeRetry(retryCount: Int): Unit = {
+      val rerunFlag = try {
+        write(inputDf, target, pipelineSnapTime, maxMergeScanDates)
+        false
+      } catch {
+        case e: Throwable =>
+          val exceptionMsg = e.getMessage.toLowerCase()
+          if (exceptionMsg != null && (exceptionMsg.contains("concurrent") || exceptionMsg.contains("conflicting")) && retryCount < 5) {
+            coolDown(target.tableFullName, 30, 30)
+            true
+          } else {
+            throw e
+          }
+      }
+      if (retryCount < 5 && rerunFlag) executeRetry(retryCount + 1)
+    }
+
+    try {
+      executeRetry(1)
+    } catch {
+      case e: Throwable =>
+        throw e
+    }
+
+  }
+
+  /**
+   * Used for multithreaded multiworkspace deployments
    * Check if a table is locked and if it is wait until max timeout for it to be unlocked and fail the write if
    * the timeout is reached
+   * Table Lock Timeout can be overridden by setting cluster spark config overwatch.tableLockTimeout -- in milliseconds
+   * default table lock timeout is 20 minutes or 1200000 millis
+   *
    * @param tableName name of the table to be written
-   * @param timeout timeout // TODO -- max this externally configurable -- historical loads for long-running modules may lock a table for a long time
    * @return
    */
-  private def targetNotLocked(tableName: String, timeout: Long = 1200000): Boolean = {
+  private def targetNotLocked(tableName: String): Boolean = {
+    val defaultTimeout: String = "1200000"
+    val timeout = spark(globalSession = true).conf.getOption("overwatch.tableLockTimeout").getOrElse(defaultTimeout).toLong
     val timerStart = System.currentTimeMillis()
 
     @tailrec def testLock(retryCount: Int): Boolean = {
@@ -292,7 +364,7 @@ class Database(config: Config) extends SparkSessionWrapper {
       if (SparkSessionWrapper.globalTableLock.contains(tableName)) {
         if (withinTimeout) {
           logger.log(Level.WARN, s"TABLE LOCKED: $tableName for $currWaitTime -- waiting for parallel writes to complete")
-          Thread.sleep(retryCount * 10000) // add 10 seconds to sleep for each lock test
+          coolDown(tableName, retryCount * 10, 2) // add 10 to 12 seconds to sleep for each lock test
           testLock(retryCount + 1)
         } else {
           throw new Exception(s"TABLE LOCK TIMEOUT - The table $tableName remained locked for more than the configured " +
@@ -300,16 +372,28 @@ class Database(config: Config) extends SparkSessionWrapper {
         }
       } else true // table not locked
     }
+
     testLock(retryCount = 1)
   }
 
 
-
-  def writeWithRetry(df: DataFrame,
-                     target: PipelineTable,
-                     pipelineSnapTime: Column,
-                     maxMergeScanDates: Array[String] = Array(),
-                     daysToProcess: Option[Int] = None): Boolean = {
+  /**
+   * Wrapper for the write function
+   * If legacy deployment retry delta write in event of race condition
+   * If multiworkspace -- implement table locking to alleviate race conditions on parallelize workspace loads
+   *
+   * @param df
+   * @param target
+   * @param pipelineSnapTime
+   * @param maxMergeScanDates
+   * @param daysToProcess
+   * @return
+   */
+  private[overwatch] def writeWithRetry(df: DataFrame,
+                                        target: PipelineTable,
+                                        pipelineSnapTime: Column,
+                                        maxMergeScanDates: Array[String] = Array(),
+                                        daysToProcess: Option[Int] = None): Unit = {
 
     val needsCache = daysToProcess.getOrElse(1000) < 5 && !target.autoOptimize
     val inputDf = if (needsCache) {
@@ -317,23 +401,22 @@ class Database(config: Config) extends SparkSessionWrapper {
       df.persist()
     } else df
     if (needsCache) inputDf.count()
-//    performRetry(inputDf,target, pipelineSnapTime, maxMergeScanDates)
-    // TODO -- build the finalDF here and use persistAndLoad here as well to ensure that is done before the write
-    //   target gets locked. Due to lazy execution, if not persist, the entire module timer may be executed
-    //   from the write function
 
-   val withMetaDf =  preWriteActions(df, target, pipelineSnapTime)
-    if (targetNotLocked(target.tableFullName)) {
-      try {
-        SparkSessionWrapper.globalTableLock.add(target.tableFullName)
-        write(withMetaDf, target, pipelineSnapTime, maxMergeScanDates,true)
-      } catch {
-        case e: Throwable => throw e
-      } finally {
-        SparkSessionWrapper.globalTableLock.remove(target.tableFullName)
+    if (!target.config.isMultiworkspaceDeployment) { // legacy deployment
+      performRetry(inputDf, target, pipelineSnapTime, maxMergeScanDates)
+    } else { // multi-workspace deployment
+      val withMetaDf = preWriteActions(df, target, pipelineSnapTime)
+      if (targetNotLocked(target.tableFullName)) {
+        try {
+          SparkSessionWrapper.globalTableLock.add(target.tableFullName)
+          write(withMetaDf, target, pipelineSnapTime, maxMergeScanDates, preWritesPerformed = true)
+        } catch {
+          case e: Throwable => throw e
+        } finally {
+          SparkSessionWrapper.globalTableLock.remove(target.tableFullName)
+        }
       }
     }
-    true
   }
 
 

--- a/src/main/scala/com/databricks/labs/overwatch/env/Database.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Database.scala
@@ -324,6 +324,13 @@ class Database(config: Config) extends SparkSessionWrapper {
       } catch {
         case e: Throwable =>
           val exceptionMsg = e.getMessage.toLowerCase()
+          logger.log(Level.WARN,
+            s"""
+               |DELTA Table Write Failure:
+               |$exceptionMsg
+               |Will Retry After a small delay.
+               |This is usually caused by multiple writes attempting to evolve the schema simultaneously
+               |""".stripMargin)
           if (exceptionMsg != null && (exceptionMsg.contains("concurrent") || exceptionMsg.contains("conflicting")) && retryCount < 5) {
             coolDown(target.tableFullName, 30, 30)
             true

--- a/src/main/scala/com/databricks/labs/overwatch/env/Database.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Database.scala
@@ -375,7 +375,9 @@ class Database(config: Config) extends SparkSessionWrapper {
           testLock(retryCount + 1)
         } else {
           throw new Exception(s"TABLE LOCK TIMEOUT - The table $tableName remained locked for more than the configured " +
-            s"max timeout of $timeout millis")
+            s"max timeout of $timeout millis. This may be increased by setting the following spark config in the cluster" +
+            s"to something higher than the default (20 minutes). Usually only necessary for historical loads. \n" +
+            s"overwatch.tableLockTimeout")
         }
       } else true // table not locked
     }

--- a/src/main/scala/com/databricks/labs/overwatch/utils/SparkSessionWrapper.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/utils/SparkSessionWrapper.scala
@@ -1,9 +1,10 @@
 package com.databricks.labs.overwatch.utils
 
-import com.databricks.labs.overwatch.utils.SparkSessionWrapper.{ parSessionsOn}
+import com.databricks.labs.overwatch.utils.SparkSessionWrapper.parSessionsOn
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SparkSession
+import org.eclipse.jetty.util.ConcurrentHashSet
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConverters._
@@ -13,6 +14,7 @@ object SparkSessionWrapper {
 
    var parSessionsOn = false
   private[overwatch] val sessionsMap = new ConcurrentHashMap[Long, SparkSession]().asScala
+  private[overwatch] val globalTableLock = new ConcurrentHashSet[String]
   private[overwatch] val globalSparkConfOverrides = Map(
     "spark.sql.shuffle.partitions" -> "400", // allow aqe to shrink
     "spark.sql.caseSensitive" -> "false",


### PR DESCRIPTION
closes #690 

@Sriram-databricks there are some todos in Database.scala.

Please review. This was just a prototype, please closely review, and rip out all the old retry code that's been commented out for now.

Also, please do some local tests and validations. We'll need to add some comments but I needed to get this working for a customer.