### PR TITLE
Passing the apiURL to getOrgID to make it thread safe

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/BronzeTransforms.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/BronzeTransforms.scala
@@ -1,13 +1,12 @@
 package com.databricks.labs.overwatch.pipeline
 
-import com.databricks.dbutils_v1.DBUtilsHolder.dbutils
+import com.databricks.labs.overwatch.api.{ApiCall, ApiCallV2}
 import com.databricks.labs.overwatch.env.Database
 import com.databricks.labs.overwatch.eventhubs.AadAuthInstance
 import com.databricks.labs.overwatch.pipeline.WorkflowsTransforms.{workflowsCleanseJobClusters, workflowsCleanseTasks}
 import com.databricks.labs.overwatch.utils.Helpers.{getDatesGlob, removeTrailingSlashes}
 import com.databricks.labs.overwatch.utils.SchemaTools.structFromJson
 import com.databricks.labs.overwatch.utils._
-import com.databricks.labs.overwatch.api.{ApiCall, ApiCallV2}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
@@ -21,13 +20,10 @@ import org.apache.spark.sql.{AnalysisException, Column, DataFrame}
 import org.apache.spark.util.SerializableConfiguration
 
 import java.time.LocalDateTime
-import java.util
-import java.util.Collections
 import java.util.concurrent.Executors
 import scala.collection.parallel.ForkJoinTaskSupport
 import scala.concurrent.forkjoin.ForkJoinPool
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
-import scala.util.{Failure, Success}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 
 trait BronzeTransforms extends SparkSessionWrapper {
@@ -1001,7 +997,7 @@ trait BronzeTransforms extends SparkSessionWrapper {
     // Build root level eventLog path prefix from clusterID and log conf
     // /some/log/prefix/cluster_id/eventlog
     val allEventLogPrefixes =
-    if(isMultiWorkSpaceDeployment && organisationId != Initializer.getOrgId) {
+    if(isMultiWorkSpaceDeployment && organisationId != Initializer.getOrgId(Some(apiEnv.workspaceURL))) {
       getAllEventLogPrefix(newLogDirsNotIdentifiedInAudit
         .unionByName(incrementalClusterWLogging), apiEnv).select('wildPrefix).distinct()
      } else {

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Initializer.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Initializer.scala
@@ -27,12 +27,41 @@ object Initializer extends SparkSessionWrapper {
   // Init the SparkSessionWrapper with envVars
   envInit()
 
-  def getOrgId: String = {
+  /**
+   * Returns the local workspace orgID
+   * @return
+   */
+  def getOrgId: String = getOrgId(None)
+
+  /**
+   * Returns the local workspace orgID, or the orgID contained in the input apiURL
+   * When getOrgId is called from a Future the apiURL MUST be passed to prevent failure to get orgID
+   * since dbutils.notebook.getContext.apiUrl.get returns None and None.get fails
+   * @param apiUrl apiURL of the workspace to get the orgId
+   * @return
+   */
+  def getOrgId(apiUrlInput: Option[String]): String = {
     val clusterOwnerOrgID = spark.conf.get("spark.databricks.clusterUsageTags.clusterOwnerOrgId")
     if (clusterOwnerOrgID == " " || clusterOwnerOrgID == "0") {
-      dbutils.notebook.getContext.apiUrl.get.split("\\.")(0).split("/").last
+      val apiURL = getApiURL(apiUrlInput)
+
+      apiURL.split("\\.")(0).split("/").lastOption match {
+        case Some(orgID) => orgID
+        case None => throw new BadConfigException("ORG ID cannot be determined")
+      }
     } else clusterOwnerOrgID
   }
+
+  private def getApiURL(apiUrlInput: Option[String]): String = {
+    apiUrlInput match {
+      case Some(apiURL) => apiURL
+      case None => dbutils.notebook.getContext.apiUrl match {
+        case Some(apiURL) => apiURL
+        case None => throw new BadConfigException("API URL cannot be determined")
+      }
+    }
+  }
+
 
   private def initConfigState(debugFlag: Boolean,organizationID: Option[String],
                               apiUrl: Option[String]
@@ -42,7 +71,7 @@ object Initializer extends SparkSessionWrapper {
 
     // If MW take orgID from arg
     if(organizationID.isEmpty) {
-      config.setOrganizationId(getOrgId)
+      config.setOrganizationId(getOrgId(apiUrl))
     }else{ // is multiWorkspace deployment since orgID is passed
       logger.log(Level.INFO, "Setting multiworkspace deployment")
       config.setOrganizationId(organizationID.get)

--- a/src/main/scala/com/databricks/labs/overwatch/utils/Tools.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/utils/Tools.scala
@@ -598,7 +598,7 @@ object Helpers extends SparkSessionWrapper {
     // verify database is owned and managed by Overwatch
     assert(dbProperties.getOrElse("OVERWATCHDB", "FALSE") == "TRUE", s"The database provided," +
       s" $etlDBWithOutCatalog, is not an Overwatch managed Database. Please provide an Overwatch managed database")
-    val workspaceID = if (isRemoteWorkspace) organization_id.get else Initializer.getOrgId
+    val workspaceID = if (isRemoteWorkspace) organization_id.get else Initializer.getOrgId(apiUrl)
 
     val statusFilter = if (successfullOnly) 'status === "SUCCESS" else lit(true)
 


### PR DESCRIPTION
Closes [882](https://github.com/databrickslabs/overwatch/issues/882)

In cases where `Initializer.getOrgId` was executed in the workers, it would result in a `None.get`. This PR overloads the method to create a thread safe alternative. 
Whenever the function was called and the apiURL was already available, I also passed it in, in case we decided to thread those paths in the future.