### PR TITLE
Fix to read mount point mapping csv file 

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/utils/Config.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/utils/Config.scala
@@ -473,7 +473,8 @@ class Config() {
         derivedApiProxy.proxyPort,
         derivedApiProxy.proxyUserName,
         derivedApiProxy.proxyPasswordScope,
-        derivedApiProxy.proxyPasswordKey
+        derivedApiProxy.proxyPasswordKey,
+        derivedApiEnvConfig.mountMappingPath
       )
     } catch {
       case e: IllegalArgumentException if e.getMessage.toLowerCase.contains("secret does not exist with scope") =>


### PR DESCRIPTION
The mount_mapping_path seems to be ignored even if thats populated as a part of the config.
This PR is a fix to address this issue.

Affected Version:
0.7.2.0