### PR TITLE
Bug fix sys table integration for sql_endpoints and migration validation

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Schema.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Schema.scala
@@ -1136,7 +1136,7 @@ object Schema extends SparkSessionWrapper {
     StructField("aad_client_id", StringType, nullable = true),
     StructField("aad_client_secret_key", StringType, nullable = true),
     StructField("aad_authority_endpoint", StringType, nullable = true),
-    StructField("sql_endpoint", StringType, nullable = false)
+    StructField("sql_endpoint", StringType, nullable = true)
   ))
 
   val mountMinimumSchema: StructType = StructType(Seq(


### PR DESCRIPTION
Adding fix for the following - 
* Validation for migration is failing for the first run
* Sql_endpoint is now not a mandatory field in configs , previously it was failing if sql_endpoints is not present in the configs