### PR TITLE
adding fix for empty EH config for system tables

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/validation/DeploymentValidation.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/validation/DeploymentValidation.scala
@@ -533,6 +533,8 @@ object DeploymentValidation extends SparkSessionWrapper {
    * @return
    */
   private def checkAAD(config: MultiWorkspaceConfig): Boolean = {
+    if(config.auditlogprefix_source_path.getOrElse("").toLowerCase.equals("system"))
+      return true
     if (config.eh_name.isEmpty)
       throw new BadConfigException("eh_name should be nonempty, please check the configuration.")
 


### PR DESCRIPTION
Mandatory validation is failing for Azure system table integration when EH details are empty . Added a fix for this issues . If audit logs are fetched from system tables EH details can be empty in the configuration  