### PR TITLE
corner case commit for job runs

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/env/Workspace.scala
@@ -296,7 +296,7 @@ class Workspace(config: Config) extends SparkSessionWrapper {
       2.1).executeMultiThread(acc)
 
     apiObj.forEach(
-      obj => if (obj.contains("runs")) {
+      obj => if (obj.contains("job_id")) {
         apiResponseArray.add(obj)
       }
     )


### PR DESCRIPTION
after traceability the meta will contain the api call details which also contains "runs" so we cannot check the response is empty or not based on runs.