### PR TITLE
Redefine views so that they are created from tables not locations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "overwatch"
 
 organization := "com.databricks.labs"
 
-version := "0.8.1.1"
+version := "0.8.2.0"
 
 scalaVersion := "2.12.12"
 scalacOptions ++= Seq("-Xmax-classfile-name", "78")

--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineView.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/PipelineView.scala
@@ -19,7 +19,7 @@ case class PipelineView(name: String,
     if (dataSource.exists) {
       val pubStatementSB = new StringBuilder("create or replace view ")
       val dataSourceName = dataSource.name.toLowerCase()
-      pubStatementSB.append(s"${dbTarget}.${name} as select ${colDefinition} from delta.`${config.etlDataPathPrefix}/${dataSourceName}`")
+      pubStatementSB.append(s"${dbTarget}.${name} as select ${colDefinition} from ${config.etlCatalogName}.${config.databaseName}.${dataSource.name}")
       // link partition columns
       if (dataSource.partitionBy.nonEmpty) {
         val partMap: Map[String, String] = if (partitionMapOverrides.isEmpty) {
@@ -27,10 +27,10 @@ case class PipelineView(name: String,
         } else {
           partitionMapOverrides
         }
-        pubStatementSB.append(s" where ${partMap.head._1} = ${s"delta.`${config.etlDataPathPrefix}/${dataSourceName}`"}.${partMap.head._2} ")
+        pubStatementSB.append(s" where ${partMap.head._1} = ${config.etlCatalogName}.${config.databaseName}.${dataSource.name}.${partMap.head._2} ")
         if (partMap.keys.toArray.length > 1) {
           partMap.tail.foreach(pCol => {
-            pubStatementSB.append(s"and ${pCol._1} = ${s"delta.`${config.etlDataPathPrefix}/${dataSourceName}`"}.${pCol._2} ")
+            pubStatementSB.append(s"and ${pCol._1} = ${config.etlCatalogName}.${config.databaseName}.${dataSource.name}.${pCol._2} ")
           })
         }
         if (workspacesAllowed.nonEmpty){


### PR DESCRIPTION
Below Logic is implemented as part of View Creation:

- First Check if the ETL tables exists.

--  If table exists then create views from the ETL tables.
-- If table not exist then
---   Check if the path exist
------ If path does not exist then skip the view creation process.
------ If path does exist then create the table and do the normal view creation process.