### PR TITLE
adjust Silver Job Runs module configuration

### DIFF
--- a/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala
+++ b/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala
@@ -268,7 +268,11 @@ class Silver(_workspace: Workspace, _database: Database, _config: Config)
       )
   }
 
-  lazy private[overwatch] val jobRunsModule = Module(2011, "Silver_JobsRuns", this, Array(1004, 2010, 2014), shuffleFactor = 12.0)
+  lazy private[overwatch] val jobRunsModule =
+    Module( 2011, "Silver_JobsRuns", this, Array(1004, 2010, 2014), shuffleFactor = 12.0)
+      .withSparkOverrides( Map(
+        "spark.databricks.adaptive.autoOptimizeShuffle.enabled" -> "true"))
+
   lazy private val appendJobRunsProcess: () => ETLDefinition = {
     () =>
       ETLDefinition(


### PR DESCRIPTION
# enable auto-optimized shuffle for module 2011

Originally implemented for Spark 3.1.2 in commit https://github.com/databrickslabs/overwatch/commit/d751d5fc75c939892b73f877cb0e5542eb2cc030 on branch [`1228-silver-job-runs-spark312-r0812`](https://github.com/databrickslabs/overwatch/tree/1228-silver-job-runs-spark312-r0812) as part of #1253. (See copy-pasted content from #1253 [below](https://github.com/databrickslabs/overwatch/pull/1256#issuecomment-2229012714).)

This PR removes all of the new utilities and transformation refactoring that were only aids to development and testing.  They did not impact performance in any significant way.

The essential change brought to this branch (`1228-optimization-only`) is entirely expressed in commit https://github.com/databrickslabs/overwatch/commit/8c9ee79d20a4904ecd5aa2908715179c58e615e1.  The new code introduced is here:
https://github.com/databrickslabs/overwatch/blob/8c9ee79d20a4904ecd5aa2908715179c58e615e1/src/main/scala/com/databricks/labs/overwatch/pipeline/Silver.scala#L271-L274

The background and analysis of the optimization presented in the [description](https://github.com/databrickslabs/overwatch/pull/1253/#issue-2375849340) of #1253 is still representative of the performance improvements realized by this change.

[proof notebook](https://adb-2753962522174656.16.azuredatabricks.net/?o=2753962522174656#notebook/2867401694842915) (IN PROGRESS) 

Corresponding job runs for before/after comparison of this change:

| `0.8.1.2` | `0.8.2.0-SNAPSHOT` |
|--------|--------|
| [Run 647559332994892](https://e2-demo-west.cloud.databricks.com/jobs/188812496658902/runs/647559332994892?focus_task=MultiWorkspaceRunner&o=2556758628403379) (210402 rows in 19.2 mins) | [Run 455980391763738](https://e2-demo-west.cloud.databricks.com/jobs/193998158504926/runs/455980391763738?focus_task=MultiWorkspaceRunner&o=2556758628403379) (210402 rows in 8.13 mins)|
| [Run 265434635290698](https://e2-demo-west.cloud.databricks.com/jobs/188812496658902/runs/265434635290698?focus_task=MultiWorkspaceRunner&o=2556758628403379) (483230 rows in 20.53 mins) | [Run 635176874378143](https://e2-demo-west.cloud.databricks.com/jobs/193998158504926/runs/635176874378143?focus_task=MultiWorkspaceRunner&o=2556758628403379) (483230 rows in 8.9 mins) | 

